### PR TITLE
Feat: 네비게이션바 생성, 일반고민등록 UI

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,14 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>앱이 갤러리에서 사진을 선택할 수 있도록 허용해주세요.</string>
+
+	<key>NSCameraUsageDescription</key>
+	<string>앱이 카메라를 사용할 수 있도록 허용해주세요.</string>
+
+	<key>NSMicrophoneUsageDescription</key>
+	<string>앱이 마이크를 사용할 수 있도록 허용해주세요.</string>
+
 </dict>
 </plist>

--- a/lib/common/go_router.dart
+++ b/lib/common/go_router.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
+import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/ai_worry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/normal_worry.dart';
+import 'package:gomin_jungdok_mobile/navigation_bar.dart';
+
+final GoRouter router = GoRouter(
+  initialLocation: '/',
+  routes: [
+    ShellRoute(
+      builder: (context, state, child) {
+        return Scaffold(
+          body: child,
+          bottomNavigationBar: Navigation_bar(
+            currentIndex:
+                _getCurrentIndex(state.uri.toString()), // state.location 사용
+            onTabSelected: (index) => _onTabSelected(context, index),
+          ),
+        );
+      },
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Mainview(),
+        ),
+        GoRoute(
+          path: '/normalWorry',
+          builder: (context, state) => NormalWorry(),
+        ),
+        GoRoute(
+          path: '/aiWorry',
+          builder: (context, state) => AiWorry(),
+        ),
+        GoRoute(
+          path: '/todayWorry',
+          builder: (context, state) => TodayWorry(),
+        ),
+        GoRoute(
+          path: '/pastWorry',
+          builder: (context, state) => PastWorry(),
+        ),
+        GoRoute(
+          path: '/myProfile',
+          builder: (context, state) => MyProfile(),
+        ),
+      ],
+    ),
+  ],
+);
+
+int _getCurrentIndex(String location) {
+  if (location == '/') return 0;
+  if (location == '/todayWorry') return 1;
+  if (location == '/normalWorry' || location == '/aiWorry')
+    return 2; // 고민등록하기 경로 추가
+  if (location == '/pastWorry') return 3;
+  if (location == '/myProfile') return 4;
+  return 0; // 기본값은 홈
+}
+
+void _onTabSelected(BuildContext context, int index) {
+  if (index == 2) {
+    // 고민등록하기 버튼 클릭 시 인덱스를 2로 설정하여 색상 변경
+    (context as Element).markNeedsBuild(); // 위젯 리빌드 강제 (필요 시)
+    _showPopupMenu(context);
+  } else {
+    context.go(_getPathFromIndex(index)); // 다른 탭은 라우트로 이동
+  }
+}
+
+String _getPathFromIndex(int index) {
+  switch (index) {
+    case 0:
+      return '/';
+    case 1:
+      return '/todayWorry';
+    case 3:
+      return '/pastWorry';
+    case 4:
+      return '/myProfile';
+    default:
+      return '/';
+  }
+}
+
+void _showPopupMenu(BuildContext context) async {
+  final RenderBox overlay =
+      Overlay.of(context).context.findRenderObject() as RenderBox;
+
+  await showMenu<String>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      overlay.size.width / 2 - 86,
+      overlay.size.height - 120,
+      overlay.size.width / 2 + 86,
+      0,
+    ),
+    items: [
+      const PopupMenuItem<String>(
+        value: 'general',
+        child: Center(child: Text('일반 고민 작성', style: TextStyle(fontSize: 16))),
+      ),
+      const PopupMenuDivider(),
+      const PopupMenuItem<String>(
+        value: 'ai',
+        child: Center(child: Text('AI 고민 작성', style: TextStyle(fontSize: 16))),
+      ),
+    ],
+    elevation: 8.0,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(12),
+    ),
+  ).then((String? value) {
+    if (value == 'general') {
+      context.go('/normalWorry'); // 고민등록하기 페이지로 이동
+    } else if (value == 'ai') {
+      context.go('/aiWorry'); // AI 고민 작성 페이지로 이동
+    }
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
 
 void main() {
   runApp(const MyApp());
@@ -6,65 +7,13 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+      debugShowCheckedModeBanner: false,
+      title: '고민중독',
+      theme: ThemeData(),
+      home: const Mainview(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gomin_jungdok_mobile/common/go_router.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
 
 void main() {
@@ -7,13 +8,13 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       debugShowCheckedModeBanner: false,
+      routerConfig: router,
       title: '고민중독',
-      theme: ThemeData(),
-      home: const Mainview(),
     );
   }
 }

--- a/lib/navigation_bar.dart
+++ b/lib/navigation_bar.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+
+class Navigation_bar extends StatelessWidget {
+  final int currentIndex;
+  final Function(int) onTabSelected;
+
+  const Navigation_bar({
+    required this.currentIndex,
+    required this.onTabSelected,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      iconSize: 20.0,
+      unselectedFontSize: 12.0,
+      selectedFontSize: 12.0,
+      currentIndex: currentIndex,
+      selectedItemColor: Color(0xFFFA743E),
+      unselectedItemColor: Colors.grey,
+      onTap: onTabSelected,
+      type: BottomNavigationBarType.fixed,
+      items: const [
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon(Icons.home),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '홈',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon(FontAwesomeIcons.fire),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '오늘의고민',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon((Icons.add)),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '고민등록하기',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon((LucideIcons.bookOpen)),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '과거의고민',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon(Icons.person),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '마이페이지',
+        ),
+      ],
+    );
+  }
+}

--- a/lib/navigation_bar.dart
+++ b/lib/navigation_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:lucide_icons/lucide_icons.dart';
+import 'package:go_router/go_router.dart';
 
 class Navigation_bar extends StatelessWidget {
   final int currentIndex;
@@ -15,68 +16,36 @@ class Navigation_bar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BottomNavigationBar(
+      backgroundColor: Colors.white,
       iconSize: 20.0,
       unselectedFontSize: 12.0,
       selectedFontSize: 12.0,
       currentIndex: currentIndex,
       selectedItemColor: Color(0xFFFA743E),
       unselectedItemColor: Colors.grey,
-      onTap: onTabSelected,
+      onTap: (index) {
+        onTabSelected(index);
+      },
       type: BottomNavigationBarType.fixed,
       items: const [
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon(Icons.home),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(Icons.home),
           label: '홈',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon(FontAwesomeIcons.fire),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(FontAwesomeIcons.fire),
           label: '오늘의고민',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon((Icons.add)),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(Icons.add),
           label: '고민등록하기',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon((LucideIcons.bookOpen)),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(LucideIcons.bookOpen),
           label: '과거의고민',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon(Icons.person),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(Icons.person),
           label: '마이페이지',
         ),
       ],

--- a/lib/worry/pastWorry.dart
+++ b/lib/worry/pastWorry.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class PastWorry extends StatelessWidget {
+  const PastWorry({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/worry/todayWorry.dart
+++ b/lib/worry/todayWorry.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class TodayWorry extends StatelessWidget {
+  const TodayWorry({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/worryRegist/ai_worry.dart
+++ b/lib/worryRegist/ai_worry.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class WorryRegist extends StatelessWidget {
-  const WorryRegist({super.key});
+class AiWorry extends StatelessWidget {
+  const AiWorry({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/worryRegist/mainView.dart
+++ b/lib/worryRegist/mainView.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:gomin_jungdok_mobile/navigation_bar.dart';
 import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
 import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/ai_worry.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
-import 'package:gomin_jungdok_mobile/worryRegist/worryRegist.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/normal_worry.dart';
 
 class Mainview extends StatefulWidget {
   const Mainview({super.key});
@@ -18,14 +19,14 @@ class _MainviewState extends State<Mainview> {
   final List<Widget> _tabs = [
     HomeContent(), // 홈
     TodayWorry(), // 오늘의 고민
-    WorryRegist(), // 고민 등록하기
+    Container(), // 고민등록하기
     PastWorry(), // 과거의 고민
-    MyProfile(), // 마이 프로필
+    MyProfile(), // 마이페이지
   ];
 
   void _onTabSelected(int index) {
     setState(() {
-      _currentIndex = index;
+      _currentIndex = index; // 다른 탭 전환
     });
   }
 
@@ -34,12 +35,10 @@ class _MainviewState extends State<Mainview> {
     return Scaffold(
       appBar: AppBar(
         title: Text('앱 메인 화면'),
+        backgroundColor: Colors.white,
       ),
       body: _tabs[_currentIndex], // 현재 선택된 콘텐츠 표시
-      bottomNavigationBar: Navigation_bar(
-        currentIndex: _currentIndex,
-        onTabSelected: _onTabSelected,
-      ),
+      backgroundColor: Colors.white,
     );
   }
 }
@@ -48,7 +47,8 @@ class HomeContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Text('홈 화면 콘텐츠', style: TextStyle(fontSize: 24)),
+      child:
+          Text('홈 화면 콘텐츠', style: TextStyle(fontSize: 24, color: Colors.red)),
     );
   }
 }

--- a/lib/worryRegist/mainView.dart
+++ b/lib/worryRegist/mainView.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:gomin_jungdok_mobile/navigation_bar.dart';
+import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
+import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/worryRegist.dart';
+
+class Mainview extends StatefulWidget {
+  const Mainview({super.key});
+
+  @override
+  _MainviewState createState() => _MainviewState();
+}
+
+class _MainviewState extends State<Mainview> {
+  int _currentIndex = 0;
+
+  final List<Widget> _tabs = [
+    HomeContent(), // 홈
+    TodayWorry(), // 오늘의 고민
+    WorryRegist(), // 고민 등록하기
+    PastWorry(), // 과거의 고민
+    MyProfile(), // 마이 프로필
+  ];
+
+  void _onTabSelected(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('앱 메인 화면'),
+      ),
+      body: _tabs[_currentIndex], // 현재 선택된 콘텐츠 표시
+      bottomNavigationBar: Navigation_bar(
+        currentIndex: _currentIndex,
+        onTabSelected: _onTabSelected,
+      ),
+    );
+  }
+}
+
+class HomeContent extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('홈 화면 콘텐츠', style: TextStyle(fontSize: 24)),
+    );
+  }
+}

--- a/lib/worryRegist/myProfile.dart
+++ b/lib/worryRegist/myProfile.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class MyProfile extends StatelessWidget {
+  const MyProfile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/worryRegist/normal_worry.dart
+++ b/lib/worryRegist/normal_worry.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+
+class NormalWorry extends StatefulWidget {
+  @override
+  _NormalWorryState createState() => _NormalWorryState();
+}
+
+class _NormalWorryState extends State<NormalWorry> {
+  final TextEditingController _introController = TextEditingController();
+  int _introTextLength = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _introController.addListener(() {
+      setState(() {
+        _introTextLength = _introController.text.length;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _introController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('일반 고민 작성'),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () {
+            context.go('/');
+          },
+        ),
+      ),
+      backgroundColor: Colors.white,
+      body: GestureDetector(
+        // 화면 터치 시 키보드 숨기기
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(30.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CustomTitleField(),
+                Divider(
+                  thickness: 1,
+                  color: Colors.grey,
+                ),
+                CustomIntroField(controller: _introController),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                  child: Text(
+                    '${_introTextLength}/100자',
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ),
+                SizedBox(height: 20),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _buildChoiceField('첫번째 선택지'),
+                    ),
+                    SizedBox(width: 10),
+                    Expanded(child: _buildChoiceField('두번째 선택지')),
+                  ],
+                ),
+                SizedBox(height: 30),
+                ElevatedButton(
+                  onPressed: () {},
+                  child: Center(child: Text('등록하기')),
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: Size(double.infinity, 50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.zero,
+                    ),
+                    backgroundColor: Colors.grey.shade300,
+                    foregroundColor: Colors.black,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChoiceField(String label) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Center(child: Text(label, style: TextStyle(color: Colors.grey))),
+        SizedBox(height: 5),
+        TextField(
+          maxLength: 15,
+          decoration: InputDecoration(
+            contentPadding: EdgeInsets.symmetric(vertical: 30, horizontal: 10),
+            border: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.grey),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.grey.shade400),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.grey, width: 1),
+            ),
+            hintText: '내용을 입력하세요',
+          ),
+          style: TextStyle(fontSize: 10),
+        ),
+      ],
+    );
+  }
+}
+
+class CustomTitleField extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 5),
+        Container(
+          height: 50,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: Colors.white),
+            borderRadius: BorderRadius.circular(0),
+          ),
+          child: TextField(
+            maxLength: 20,
+            decoration: const InputDecoration(
+              hintText: '제목을 입력하세요',
+              hintStyle: TextStyle(
+                fontSize: 20,
+                color: Colors.grey,
+              ),
+              border: InputBorder.none,
+            ),
+            style: const TextStyle(
+              fontSize: 15,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class CustomIntroField extends StatelessWidget {
+  final TextEditingController controller;
+
+  CustomIntroField({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 5),
+        Container(
+          height: 180,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: Colors.white),
+            borderRadius: BorderRadius.circular(0),
+          ),
+          child: TextField(
+            controller: controller,
+            maxLines: 4,
+            inputFormatters: [
+              LengthLimitingTextInputFormatter(100),
+            ],
+            decoration: const InputDecoration(
+              hintText: '설명을 입력하세요',
+              hintStyle: TextStyle(
+                fontSize: 12,
+                color: Colors.grey,
+              ),
+              border: InputBorder.none,
+            ),
+            style: const TextStyle(
+              fontSize: 12,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/worryRegist/worryRegist.dart
+++ b/lib/worryRegist/worryRegist.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class WorryRegist extends StatelessWidget {
+  const WorryRegist({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,43 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -57,6 +65,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -70,8 +110,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.24"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -83,6 +136,94 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.8.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "04539267a740931c6d4479a10d466717ca5901c6fdfd3fcda09391bbb8ebd651"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+20"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   leak_tracker:
     dependency: transitive
     description:
@@ -115,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   lucide_icons:
     dependency: "direct main"
     description:
@@ -147,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -155,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -224,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.6.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.24.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: d3a89184101baec7f4600d58840a764d2ef760fe1c5a20ef9e6b0e9b24a07a3a
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -107,6 +115,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  lucide_icons:
+    dependency: "direct main"
+    description:
+      name: lucide_icons
+      sha256: ad24d0fd65707e48add30bebada7d90bff2a1bba0a72d6e9b19d44246b0e83c4
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.257.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -83,6 +88,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.8.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "04539267a740931c6d4479a10d466717ca5901c6fdfd3fcda09391bbb8ebd651"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -115,6 +128,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   lucide_icons:
     dependency: "direct main"
     description:
@@ -226,4 +247,4 @@ packages:
     version: "14.3.0"
 sdks:
   dart: ">=3.6.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   lucide_icons: ^0.257.0
   font_awesome_flutter: ^10.8.0
+  go_router: ^14.8.0
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  lucide_icons: ^0.257.0
+  font_awesome_flutter: ^10.8.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   lucide_icons: ^0.257.0
   font_awesome_flutter: ^10.8.0
+  go_router: ^14.8.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
**Description**
깃허브의 branch 생성을 익히기 위해 첫 화면 navigation_bar UI를 만들어보았습니다. 
<img width="434" alt="스크린샷 2025-02-07 오후 8 39 55" src="https://github.com/user-attachments/assets/0a0ad943-d32b-4d0f-bbf0-29398687996f" />

**생성 폴더**
common : 주소와 같은 상수, 고정 layout, 공통 요소들을 보관하기 위해 만들었습니다.
login : 고민등록 페이지를 만들고 나서 만들 login 폴더입니다.
worry : 오늘의 고민, 과거의 고민 페이지를 StatelessWidget로 구성했습니다.
worryRegist : 홈 화면인 mainView.dart, 마이페이지(ui 이동용), 고민등록 페이지를 넣었습니다.


**그 밖의 파일**
main.dart
navigation_bar : mainView.dart 파일에서 Mainview 클래스가 모든 페이지의 부모 위젯으로 설정해놨기 때문에, 앱 내에서 다른 콘텐츠를 표시할 때 Navigation_bar가 유지될 수 있게 했습니다. 아마 Navigation.push와 같은 기능을 사용할 때는 다시 수정해야 할 것 같습니다. UI만 짰기 때문입니다.

**추가된 패키지**
Icon을 위한 패키지 2개

## 2월 9일자 고민 등록하기 기능 구현

처음에 pr 올린 부분에서 navigation_bar를 수정했습니다. mainView.dart 부분이 혜민님, 서현님이 이어서 구현하시는 페이지라고 생각을 했고 고민등록하기 버튼을 누르면 mainView.dart 화면에서 페이지 전환 없이 팝업으로 일반고민, ai고민을 선택하는 기능을 구현해야 했기 때문입니다. 따라서 navigation_bar에서 index로 페이지 전환이 일어나는 현재 if문으로 index==2(고민등록) 일때 조건을 걸었습니다.

추가 패키지 : go_router

## 2월 12일자 고민 등록하기 기능 구현

navigation_bar를 상시적으로 띄우기 위해서 코드 수정이 있었습니다. 우선 navigation_bar.dart 파일에서는 ui만 담당하고, navigation_bar를 선택했을 때 이동하는 경로나 페이지 라우팅은 go_router.dart에서 모두 담당하도록 코드를 수정했습니다. 이에 따라서 mainView.dart 파일에서는 navigation_bar의 클래스를 불러오지 않아도 되도록 했습니다.
현재까지 commit 한 부분은 일반고민등록에서 내용 부분에 이미지 삽입 전 부분까지 구현했습니다.
<img width="457" alt="image" src="https://github.com/user-attachments/assets/dc1070b9-0666-4cfe-b51a-1953c3b18502" />

