### PR TITLE
Feat:데모데이 전 완료된 UI

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="gomin_jungdok_mobile"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Flutter (1.0.0)
+  - image_picker_ios (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
+
+SPEC CHECKSUMS:
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+
+PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,9 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		133FD0017BFB989F00E8EC27 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2D84E68966AB77710DFC51E /* Pods_RunnerTests.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		6D29746B0DA29156AD00B087 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEC1218B04C632CA2EC8A831 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -47,7 +49,10 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		792E79D93AC06D81A4D28055 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7C6360EDBED1DCD55DB607B2 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		7FC51E453FE17CEEC051291B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,13 +60,27 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AF2A1222313117C2D42E0F8E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		C15D3DC36534A7398C6C6F74 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		C3A050A488A722DF925BE4CB /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E2D84E68966AB77710DFC51E /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EEC1218B04C632CA2EC8A831 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4403B9B065E46624C47C3DFE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				133FD0017BFB989F00E8EC27 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D29746B0DA29156AD00B087 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +93,15 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		3B4ED34578FF1640CEAF487F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EEC1218B04C632CA2EC8A831 /* Pods_Runner.framework */,
+				E2D84E68966AB77710DFC51E /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +122,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				A62B79012D2D153A2BEE1375 /* Pods */,
+				3B4ED34578FF1640CEAF487F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +151,20 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		A62B79012D2D153A2BEE1375 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				7C6360EDBED1DCD55DB607B2 /* Pods-Runner.debug.xcconfig */,
+				AF2A1222313117C2D42E0F8E /* Pods-Runner.release.xcconfig */,
+				792E79D93AC06D81A4D28055 /* Pods-Runner.profile.xcconfig */,
+				C3A050A488A722DF925BE4CB /* Pods-RunnerTests.debug.xcconfig */,
+				7FC51E453FE17CEEC051291B /* Pods-RunnerTests.release.xcconfig */,
+				C15D3DC36534A7398C6C6F74 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				BB36F48B2070AA1E66D29DCE /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				4403B9B065E46624C47C3DFE /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				852DA1F0237D75BD7DEDE48B /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				31B9EBFFA6D9D8002681A182 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +270,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		31B9EBFFA6D9D8002681A182 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -238,6 +303,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		852DA1F0237D75BD7DEDE48B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +339,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		BB36F48B2070AA1E66D29DCE /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -379,6 +488,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C3A050A488A722DF925BE4CB /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -396,6 +506,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7FC51E453FE17CEEC051291B /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -411,6 +522,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C15D3DC36534A7398C6C6F74 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,12 +47,16 @@
 	<true/>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>앱이 갤러리에서 사진을 선택할 수 있도록 허용해주세요.</string>
-
 	<key>NSCameraUsageDescription</key>
 	<string>앱이 카메라를 사용할 수 있도록 허용해주세요.</string>
-
 	<key>NSMicrophoneUsageDescription</key>
 	<string>앱이 마이크를 사용할 수 있도록 허용해주세요.</string>
 
+	<!-- 🚀 네트워크 설정 수정 (올바른 구조) -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,14 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>앱이 갤러리에서 사진을 선택할 수 있도록 허용해주세요.</string>
+
+	<key>NSCameraUsageDescription</key>
+	<string>앱이 카메라를 사용할 수 있도록 허용해주세요.</string>
+
+	<key>NSMicrophoneUsageDescription</key>
+	<string>앱이 마이크를 사용할 수 있도록 허용해주세요.</string>
+
 </dict>
 </plist>

--- a/lib/common/const/apiUrl.dart
+++ b/lib/common/const/apiUrl.dart
@@ -1,0 +1,1 @@
+final String apiURL = "http://34.47.92.139:8080";

--- a/lib/common/go_router.dart
+++ b/lib/common/go_router.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
+import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/ai_worry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/normal_worry.dart';
+import 'package:gomin_jungdok_mobile/navigation_bar.dart';
+
+final GoRouter router = GoRouter(
+  initialLocation: '/',
+  routes: [
+    ShellRoute(
+      builder: (context, state, child) {
+        return Scaffold(
+          body: child,
+          bottomNavigationBar: Navigation_bar(
+            currentIndex:
+                _getCurrentIndex(state.uri.toString()), // state.location 사용
+            onTabSelected: (index) => _onTabSelected(context, index),
+          ),
+        );
+      },
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Mainview(),
+        ),
+        GoRoute(
+          path: '/normalWorry',
+          builder: (context, state) => NormalWorry(),
+        ),
+        GoRoute(
+          path: '/aiWorry',
+          builder: (context, state) => AiWorry(),
+        ),
+        GoRoute(
+          path: '/todayWorry',
+          builder: (context, state) => TodayWorry(),
+        ),
+        GoRoute(
+          path: '/pastWorry',
+          builder: (context, state) => PastWorry(),
+        ),
+        GoRoute(
+          path: '/myProfile',
+          builder: (context, state) => MyProfile(),
+        ),
+      ],
+    ),
+  ],
+);
+
+int _getCurrentIndex(String location) {
+  if (location == '/') return 0;
+  if (location == '/todayWorry') return 1;
+  if (location == '/normalWorry' || location == '/aiWorry')
+    return 2; // 고민등록하기 경로 추가
+  if (location == '/pastWorry') return 3;
+  if (location == '/myProfile') return 4;
+  return 0; // 기본값은 홈
+}
+
+void _onTabSelected(BuildContext context, int index) {
+  if (index == 2) {
+    // 고민등록하기 버튼 클릭 시 인덱스를 2로 설정하여 색상 변경
+    (context as Element).markNeedsBuild(); // 위젯 리빌드 강제 (필요 시)
+    _showPopupMenu(context);
+  } else {
+    context.go(_getPathFromIndex(index)); // 다른 탭은 라우트로 이동
+  }
+}
+
+String _getPathFromIndex(int index) {
+  switch (index) {
+    case 0:
+      return '/';
+    case 1:
+      return '/todayWorry';
+    case 3:
+      return '/pastWorry';
+    case 4:
+      return '/myProfile';
+    default:
+      return '/';
+  }
+}
+
+void _showPopupMenu(BuildContext context) async {
+  final RenderBox overlay =
+      Overlay.of(context).context.findRenderObject() as RenderBox;
+
+  await showMenu<String>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      overlay.size.width / 2 - 86,
+      overlay.size.height - 120,
+      overlay.size.width / 2 + 86,
+      0,
+    ),
+    items: [
+      const PopupMenuItem<String>(
+        value: 'general',
+        child: Center(child: Text('일반 고민 작성', style: TextStyle(fontSize: 16))),
+      ),
+      const PopupMenuDivider(),
+      const PopupMenuItem<String>(
+        value: 'ai',
+        child: Center(child: Text('AI 고민 작성', style: TextStyle(fontSize: 16))),
+      ),
+    ],
+    elevation: 8.0,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(12),
+    ),
+  ).then((String? value) {
+    if (value == 'general') {
+      context.go('/normalWorry'); // 고민등록하기 페이지로 이동
+    } else if (value == 'ai') {
+      context.go('/aiWorry'); // AI 고민 작성 페이지로 이동
+    }
+  });
+}

--- a/lib/go_router.dart
+++ b/lib/go_router.dart
@@ -51,17 +51,8 @@ final GoRouter router = GoRouter(
           builder: (context, state) => MyProfile(),
         ),
         GoRoute(
-          path: '/aiWorry_analyze',
-          builder: (context, state) {
-            final selectedImage = state.extra as File?; // 🛠 null 가능성 고려
-
-            if (selectedImage == null) {
-              // 🔥 예외 처리: 선택된 이미지가 없으면 이전 화면으로 이동
-              return const AiWorry();
-            }
-
-            return AiAnalyze(selectedImage: selectedImage);
-          },
+          path: '/aiWorryAnalyze',
+          builder: (context, state) => AiAnalyze(),
         ),
       ],
     ),

--- a/lib/go_router.dart
+++ b/lib/go_router.dart
@@ -95,25 +95,36 @@ void _showPopupMenu(BuildContext context) async {
     context: context,
     position: RelativeRect.fromLTRB(
       overlay.size.width / 2 - 86,
-      overlay.size.height - 120,
+      overlay.size.height - 220,
       overlay.size.width / 2 + 86,
       0,
     ),
-    items: [
-      const PopupMenuItem<String>(
-        value: 'general',
-        child: Center(child: Text('일반 고민 작성', style: TextStyle(fontSize: 16))),
-      ),
-      const PopupMenuDivider(),
-      const PopupMenuItem<String>(
-        value: 'ai',
-        child: Center(child: Text('AI 고민 작성', style: TextStyle(fontSize: 16))),
-      ),
-    ],
     elevation: 8.0,
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(12),
     ),
+    color: Colors.white,
+    items: [
+      const PopupMenuItem<String>(
+        value: 'general',
+        child: Center(
+          child: Text(
+            '일반 고민 작성',
+            style: TextStyle(fontSize: 16, color: Colors.black),
+          ),
+        ),
+      ),
+      const PopupMenuDivider(),
+      const PopupMenuItem<String>(
+        value: 'ai',
+        child: Center(
+          child: Text(
+            'AI 고민 작성',
+            style: TextStyle(fontSize: 16, color: Colors.black),
+          ),
+        ),
+      ),
+    ],
   ).then((String? value) {
     if (value == 'general') {
       context.go('/normalWorry'); // 고민등록하기 페이지로 이동

--- a/lib/go_router.dart
+++ b/lib/go_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
 import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/ai_analyze.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/ai_worry.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
@@ -46,6 +47,10 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: '/myProfile',
           builder: (context, state) => MyProfile(),
+        ),
+        GoRoute(
+          path: '/aiWorry_analyze',
+          builder: (context, state) => AiAnalyze(),
         ),
       ],
     ),

--- a/lib/go_router.dart
+++ b/lib/go_router.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
@@ -50,7 +52,16 @@ final GoRouter router = GoRouter(
         ),
         GoRoute(
           path: '/aiWorry_analyze',
-          builder: (context, state) => AiAnalyze(),
+          builder: (context, state) {
+            final selectedImage = state.extra as File?; // 🛠 null 가능성 고려
+
+            if (selectedImage == null) {
+              // 🔥 예외 처리: 선택된 이미지가 없으면 이전 화면으로 이동
+              return const AiWorry();
+            }
+
+            return AiAnalyze(selectedImage: selectedImage);
+          },
         ),
       ],
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:gomin_jungdok_mobile/common/go_router.dart';
+import 'package:gomin_jungdok_mobile/go_router.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/tooltip_screen.dart';
 
 void main() {
   runApp(const MyApp());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
 
 void main() {
   runApp(const MyApp());
@@ -6,65 +7,13 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+      debugShowCheckedModeBanner: false,
+      title: '고민중독',
+      theme: ThemeData(),
+      home: const Mainview(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gomin_jungdok_mobile/common/go_router.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/mainView.dart';
 
 void main() {
@@ -7,13 +8,13 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       debugShowCheckedModeBanner: false,
+      routerConfig: router,
       title: '고민중독',
-      theme: ThemeData(),
-      home: const Mainview(),
     );
   }
 }

--- a/lib/navigation_bar.dart
+++ b/lib/navigation_bar.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:lucide_icons/lucide_icons.dart';
+
+class Navigation_bar extends StatelessWidget {
+  final int currentIndex;
+  final Function(int) onTabSelected;
+
+  const Navigation_bar({
+    required this.currentIndex,
+    required this.onTabSelected,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      iconSize: 20.0,
+      unselectedFontSize: 12.0,
+      selectedFontSize: 12.0,
+      currentIndex: currentIndex,
+      selectedItemColor: Color(0xFFFA743E),
+      unselectedItemColor: Colors.grey,
+      onTap: onTabSelected,
+      type: BottomNavigationBarType.fixed,
+      items: const [
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon(Icons.home),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '홈',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon(FontAwesomeIcons.fire),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '오늘의고민',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon((Icons.add)),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '고민등록하기',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon((LucideIcons.bookOpen)),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '과거의고민',
+        ),
+        BottomNavigationBarItem(
+          icon: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(height: 4),
+              Icon(Icons.person),
+              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
+            ],
+          ),
+          label: '마이페이지',
+        ),
+      ],
+    );
+  }
+}

--- a/lib/navigation_bar.dart
+++ b/lib/navigation_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:lucide_icons/lucide_icons.dart';
+import 'package:go_router/go_router.dart';
 
 class Navigation_bar extends StatelessWidget {
   final int currentIndex;
@@ -15,68 +16,36 @@ class Navigation_bar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BottomNavigationBar(
+      backgroundColor: Colors.white,
       iconSize: 20.0,
       unselectedFontSize: 12.0,
       selectedFontSize: 12.0,
       currentIndex: currentIndex,
       selectedItemColor: Color(0xFFFA743E),
       unselectedItemColor: Colors.grey,
-      onTap: onTabSelected,
+      onTap: (index) {
+        onTabSelected(index);
+      },
       type: BottomNavigationBarType.fixed,
       items: const [
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon(Icons.home),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(Icons.home),
           label: '홈',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon(FontAwesomeIcons.fire),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(FontAwesomeIcons.fire),
           label: '오늘의고민',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon((Icons.add)),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(Icons.add),
           label: '고민등록하기',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon((LucideIcons.bookOpen)),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(LucideIcons.bookOpen),
           label: '과거의고민',
         ),
         BottomNavigationBarItem(
-          icon: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: 4),
-              Icon(Icons.person),
-              SizedBox(height: 5), // 아이콘과 라벨 사이 간격 조정
-            ],
-          ),
+          icon: Icon(Icons.person),
           label: '마이페이지',
         ),
       ],

--- a/lib/worry/pastWorry.dart
+++ b/lib/worry/pastWorry.dart
@@ -5,6 +5,14 @@ class PastWorry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      body: Center(
+        child: Text(
+          '과거 고민 등록 페이지',
+          style: TextStyle(fontSize: 24, color: Colors.red),
+        ),
+      ),
+      backgroundColor: Colors.white,
+    );
   }
 }

--- a/lib/worry/pastWorry.dart
+++ b/lib/worry/pastWorry.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class PastWorry extends StatelessWidget {
+  const PastWorry({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/worry/todayWorry.dart
+++ b/lib/worry/todayWorry.dart
@@ -5,6 +5,14 @@ class TodayWorry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      body: Center(
+        child: Text(
+          '오늘의 고민 페이지',
+          style: TextStyle(fontSize: 24, color: Colors.red),
+        ),
+      ),
+      backgroundColor: Colors.white,
+    );
   }
 }

--- a/lib/worry/todayWorry.dart
+++ b/lib/worry/todayWorry.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class TodayWorry extends StatelessWidget {
+  const TodayWorry({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/worryRegist/ai_analyze.dart
+++ b/lib/worryRegist/ai_analyze.dart
@@ -1,47 +1,114 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gomin_jungdok_mobile/common/const/apiUrl.dart';
 
 class AiAnalyze extends StatefulWidget {
-  const AiAnalyze({super.key});
+  final File selectedImage; // ✅ 전달받은 이미지
+
+  const AiAnalyze({super.key, required this.selectedImage});
 
   @override
   _AiAnalyzeState createState() => _AiAnalyzeState();
 }
 
 class _AiAnalyzeState extends State<AiAnalyze> {
-  int? _selectedTitleIndex; // 선택한 고민 제목 index
+  int? _selectedTitleIndex;
+  List<String> _recommendedTitles = ["AI 분석을 진행해주세요", "", ""];
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _analyzeImage(); // ✅ 페이지 열리자마자 AI 분석 실행
+  }
+
+  // AI 분석 요청 (이미지를 서버로 전송)
+  Future<void> _analyzeImage() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      Dio dio = Dio();
+      FormData formData = FormData.fromMap({
+        "image": await MultipartFile.fromFile(widget.selectedImage.path),
+      });
+
+      Response response = await dio.post(
+        "$apiURL/api/tensorFlowModel",
+        data: formData,
+        options: Options(headers: {"Content-Type": "multipart/form-data"}),
+      );
+
+      if (response.statusCode == 200 && response.data != null) {
+        List<String> fetchedTitles = List<String>.from(
+            response.data["message"]); // ✅ "message" 키에서 값 가져오기
+
+        setState(() {
+          _recommendedTitles = fetchedTitles.isNotEmpty
+              ? fetchedTitles
+              : ["추천 제목 없음", "추천 제목 없음", "추천 제목 없음"];
+        });
+      } else {
+        throw Exception("AI 추천 제목 불러오기 실패");
+      }
+    } catch (e) {
+      setState(() {
+        _recommendedTitles = ["불러오기 실패", "불러오기 실패", "불러오기 실패"];
+      });
+      print("❌ AI 추천 제목 불러오기 오류: $e");
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: PreferredSize(
-        preferredSize: Size.fromHeight(kToolbarHeight),
-        child: Container(
-          color: Colors.white,
-          child: SafeArea(
-            child: AppBar(
-              backgroundColor: Colors.transparent,
-              elevation: 0,
-              leading: IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.black),
-                onPressed: () {
-                  context.go('/aiWorry');
-                },
-              ),
-            ),
-          ),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () {
+            context.go('/aiWorry');
+          },
         ),
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Divider(thickness: 1, color: Colors.grey),
-          SizedBox(
-            height: 80,
+          Center(
+            child: widget.selectedImage != null
+                ? Image.file(widget.selectedImage,
+                    width: 150, height: 150, fit: BoxFit.cover)
+                : const Text("선택된 이미지 없음"),
           ),
 
-          // 📌 고민 제목 리스트 (AI 추천)
+          const SizedBox(height: 20),
+
+          // AI 분석 버튼
+          Center(
+            child: ElevatedButton(
+              onPressed: _isLoading ? null : _analyzeImage,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFFA743E),
+                foregroundColor: Colors.white,
+              ),
+              child: _isLoading
+                  ? const CircularProgressIndicator(color: Colors.white)
+                  : const Text("AI 분석 다시 실행"),
+            ),
+          ),
+
+          const SizedBox(height: 40),
+
+          // AI 추천 제목 리스트
           Column(
             children: List.generate(3, (index) {
               final bool isSelected = _selectedTitleIndex == index;
@@ -49,140 +116,34 @@ class _AiAnalyzeState extends State<AiAnalyze> {
               return GestureDetector(
                 onTap: () {
                   setState(() {
-                    _selectedTitleIndex = index; // ✅ 리스트 전체 터치 시 선택 가능
+                    _selectedTitleIndex = index;
                   });
                 },
                 child: Container(
-                  width: double.infinity, // ✅ 가로 전체 차지
+                  width: double.infinity,
                   decoration: BoxDecoration(
                     color: isSelected
                         ? const Color(0xFFFFF0EB)
-                        : Colors.transparent, // ✅ 선택된 항목 배경 확장
-                    border: Border(
-                      bottom: const BorderSide(
-                          color: Colors.grey, width: 1), // ✅ 아래 Divider 포함
-                    ),
+                        : Colors.transparent,
+                    border: const Border(
+                        bottom: BorderSide(color: Colors.grey, width: 1)),
                   ),
-                  child: Column(
-                    children: [
-                      // ✅ 첫 번째 항목인 경우, 위 Divider를 포함하여 배경과 자연스럽게 연결
-                      if (index == 0)
-                        const Divider(
-                          thickness: 1,
-                          color: Colors.grey,
-                          height: 0, // ✅ 불필요한 여백 제거
-                        ),
-
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 16, horizontal: 20), // ✅ 내부 여백 추가
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  "AI가 추천하는 제목 ${index + 1}",
-                                  style: TextStyle(
-                                    fontSize: 16,
-                                    color: Colors.grey.shade600,
-                                    fontWeight: isSelected
-                                        ? FontWeight.bold
-                                        : FontWeight.normal,
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  "고민제목이 표시됩니다",
-                                  style: TextStyle(
-                                    fontSize: 20,
-                                    color: isSelected
-                                        ? const Color(0xFFFA743E)
-                                        : Colors.black,
-                                    fontWeight: isSelected
-                                        ? FontWeight.bold
-                                        : FontWeight.normal,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            Radio<int>(
-                              value: index,
-                              groupValue: _selectedTitleIndex,
-                              activeColor: const Color(0xFFFA743E),
-                              onChanged: (int? value) {
-                                setState(() {
-                                  _selectedTitleIndex = value;
-                                });
-                              },
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 16, horizontal: 20),
+                    child: Text(
+                      _recommendedTitles[index],
+                      style: TextStyle(
+                          fontSize: 20,
+                          color: isSelected
+                              ? const Color(0xFFFA743E)
+                              : Colors.black),
+                    ),
                   ),
                 ),
               );
             }),
           ),
-
-          const Spacer(), // 버튼을 아래로 밀어주는 역할
-
-          // 📌 하단 버튼
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20), // ✅ 버튼 패딩 추가
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                // 다시 추천 받기 버튼
-                SizedBox(
-                  width: 150,
-                  height: 50,
-                  child: ElevatedButton(
-                    onPressed: () {
-                      setState(() {
-                        _selectedTitleIndex = null; // 선택 초기화
-                      });
-                    },
-                    style: ElevatedButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(0),
-                      ),
-                      backgroundColor: Colors.grey.shade500,
-                      foregroundColor: Colors.white,
-                    ),
-                    child: const Text('다시 추천 받기'),
-                  ),
-                ),
-
-                // 고민 작성하기 버튼
-                SizedBox(
-                  width: 150,
-                  height: 50,
-                  child: ElevatedButton(
-                    onPressed: _selectedTitleIndex != null
-                        ? () {
-                            // TODO: 고민 작성하기 로직 추가
-                            print("고민 작성 화면으로 이동");
-                          }
-                        : null, // 선택 안하면 비활성화
-                    style: ElevatedButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(0),
-                      ),
-                      backgroundColor: _selectedTitleIndex != null
-                          ? const Color(0xFFFA743E)
-                          : Colors.grey.shade300,
-                      foregroundColor: Colors.white,
-                    ),
-                    child: const Text('고민 작성하기'),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 20), // 하단 여백 추가
         ],
       ),
     );

--- a/lib/worryRegist/ai_analyze.dart
+++ b/lib/worryRegist/ai_analyze.dart
@@ -1,114 +1,47 @@
-import 'dart:io';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:gomin_jungdok_mobile/common/const/apiUrl.dart';
 
 class AiAnalyze extends StatefulWidget {
-  final File selectedImage; // ✅ 전달받은 이미지
-
-  const AiAnalyze({super.key, required this.selectedImage});
+  const AiAnalyze({super.key});
 
   @override
   _AiAnalyzeState createState() => _AiAnalyzeState();
 }
 
 class _AiAnalyzeState extends State<AiAnalyze> {
-  int? _selectedTitleIndex;
-  List<String> _recommendedTitles = ["AI 분석을 진행해주세요", "", ""];
-  bool _isLoading = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _analyzeImage(); // ✅ 페이지 열리자마자 AI 분석 실행
-  }
-
-  // AI 분석 요청 (이미지를 서버로 전송)
-  Future<void> _analyzeImage() async {
-    setState(() {
-      _isLoading = true;
-    });
-
-    try {
-      Dio dio = Dio();
-      FormData formData = FormData.fromMap({
-        "image": await MultipartFile.fromFile(widget.selectedImage.path),
-      });
-
-      Response response = await dio.post(
-        "$apiURL/api/tensorFlowModel",
-        data: formData,
-        options: Options(headers: {"Content-Type": "multipart/form-data"}),
-      );
-
-      if (response.statusCode == 200 && response.data != null) {
-        List<String> fetchedTitles = List<String>.from(
-            response.data["message"]); // ✅ "message" 키에서 값 가져오기
-
-        setState(() {
-          _recommendedTitles = fetchedTitles.isNotEmpty
-              ? fetchedTitles
-              : ["추천 제목 없음", "추천 제목 없음", "추천 제목 없음"];
-        });
-      } else {
-        throw Exception("AI 추천 제목 불러오기 실패");
-      }
-    } catch (e) {
-      setState(() {
-        _recommendedTitles = ["불러오기 실패", "불러오기 실패", "불러오기 실패"];
-      });
-      print("❌ AI 추천 제목 불러오기 오류: $e");
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
-    }
-  }
+  int? _selectedTitleIndex; // 선택한 고민 제목 index
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.black),
-          onPressed: () {
-            context.go('/aiWorry');
-          },
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: Colors.white,
+          child: SafeArea(
+            child: AppBar(
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.black),
+                onPressed: () {
+                  context.go('/aiWorry');
+                },
+              ),
+            ),
+          ),
         ),
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Center(
-            child: widget.selectedImage != null
-                ? Image.file(widget.selectedImage,
-                    width: 150, height: 150, fit: BoxFit.cover)
-                : const Text("선택된 이미지 없음"),
+          Divider(thickness: 1, color: Colors.grey),
+          SizedBox(
+            height: 80,
           ),
 
-          const SizedBox(height: 20),
-
-          // AI 분석 버튼
-          Center(
-            child: ElevatedButton(
-              onPressed: _isLoading ? null : _analyzeImage,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFFFA743E),
-                foregroundColor: Colors.white,
-              ),
-              child: _isLoading
-                  ? const CircularProgressIndicator(color: Colors.white)
-                  : const Text("AI 분석 다시 실행"),
-            ),
-          ),
-
-          const SizedBox(height: 40),
-
-          // AI 추천 제목 리스트
+          // 📌 고민 제목 리스트 (AI 추천)
           Column(
             children: List.generate(3, (index) {
               final bool isSelected = _selectedTitleIndex == index;
@@ -116,34 +49,140 @@ class _AiAnalyzeState extends State<AiAnalyze> {
               return GestureDetector(
                 onTap: () {
                   setState(() {
-                    _selectedTitleIndex = index;
+                    _selectedTitleIndex = index; // ✅ 리스트 전체 터치 시 선택 가능
                   });
                 },
                 child: Container(
-                  width: double.infinity,
+                  width: double.infinity, // ✅ 가로 전체 차지
                   decoration: BoxDecoration(
                     color: isSelected
                         ? const Color(0xFFFFF0EB)
-                        : Colors.transparent,
-                    border: const Border(
-                        bottom: BorderSide(color: Colors.grey, width: 1)),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: 16, horizontal: 20),
-                    child: Text(
-                      _recommendedTitles[index],
-                      style: TextStyle(
-                          fontSize: 20,
-                          color: isSelected
-                              ? const Color(0xFFFA743E)
-                              : Colors.black),
+                        : Colors.transparent, // ✅ 선택된 항목 배경 확장
+                    border: Border(
+                      bottom: const BorderSide(
+                          color: Colors.grey, width: 1), // ✅ 아래 Divider 포함
                     ),
+                  ),
+                  child: Column(
+                    children: [
+                      // ✅ 첫 번째 항목인 경우, 위 Divider를 포함하여 배경과 자연스럽게 연결
+                      if (index == 0)
+                        const Divider(
+                          thickness: 1,
+                          color: Colors.grey,
+                          height: 0, // ✅ 불필요한 여백 제거
+                        ),
+
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 16, horizontal: 20), // ✅ 내부 여백 추가
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  "AI가 추천하는 제목 ${index + 1}",
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: Colors.grey.shade600,
+                                    fontWeight: isSelected
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  "고민제목이 표시됩니다",
+                                  style: TextStyle(
+                                    fontSize: 20,
+                                    color: isSelected
+                                        ? const Color(0xFFFA743E)
+                                        : Colors.black,
+                                    fontWeight: isSelected
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            Radio<int>(
+                              value: index,
+                              groupValue: _selectedTitleIndex,
+                              activeColor: const Color(0xFFFA743E),
+                              onChanged: (int? value) {
+                                setState(() {
+                                  _selectedTitleIndex = value;
+                                });
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               );
             }),
           ),
+
+          const Spacer(), // 버튼을 아래로 밀어주는 역할
+
+          // 📌 하단 버튼
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20), // ✅ 버튼 패딩 추가
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                // 다시 추천 받기 버튼
+                SizedBox(
+                  width: 150,
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      setState(() {
+                        _selectedTitleIndex = null; // 선택 초기화
+                      });
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(0),
+                      ),
+                      backgroundColor: Colors.grey.shade500,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('다시 추천 받기'),
+                  ),
+                ),
+
+                // 고민 작성하기 버튼
+                SizedBox(
+                  width: 150,
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: _selectedTitleIndex != null
+                        ? () {
+                            // TODO: 고민 작성하기 로직 추가
+                            print("고민 작성 화면으로 이동");
+                          }
+                        : null, // 선택 안하면 비활성화
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(0),
+                      ),
+                      backgroundColor: _selectedTitleIndex != null
+                          ? const Color(0xFFFA743E)
+                          : Colors.grey.shade300,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('고민 작성하기'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20), // 하단 여백 추가
         ],
       ),
     );

--- a/lib/worryRegist/ai_analyze.dart
+++ b/lib/worryRegist/ai_analyze.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class AiAnalyze extends StatefulWidget {
+  const AiAnalyze({super.key});
+
+  @override
+  _AiAnalyzeState createState() => _AiAnalyzeState();
+}
+
+class _AiAnalyzeState extends State<AiAnalyze> {
+  int? _selectedTitleIndex; // 선택한 고민 제목 index
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: Colors.white,
+          child: SafeArea(
+            child: AppBar(
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.black),
+                onPressed: () {
+                  context.go('/aiWorry');
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Divider(thickness: 1, color: Colors.grey),
+          SizedBox(
+            height: 80,
+          ),
+
+          // 📌 고민 제목 리스트 (AI 추천)
+          Column(
+            children: List.generate(3, (index) {
+              final bool isSelected = _selectedTitleIndex == index;
+
+              return GestureDetector(
+                onTap: () {
+                  setState(() {
+                    _selectedTitleIndex = index; // ✅ 리스트 전체 터치 시 선택 가능
+                  });
+                },
+                child: Container(
+                  width: double.infinity, // ✅ 가로 전체 차지
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? const Color(0xFFFFF0EB)
+                        : Colors.transparent, // ✅ 선택된 항목 배경 확장
+                    border: Border(
+                      bottom: const BorderSide(
+                          color: Colors.grey, width: 1), // ✅ 아래 Divider 포함
+                    ),
+                  ),
+                  child: Column(
+                    children: [
+                      // ✅ 첫 번째 항목인 경우, 위 Divider를 포함하여 배경과 자연스럽게 연결
+                      if (index == 0)
+                        const Divider(
+                          thickness: 1,
+                          color: Colors.grey,
+                          height: 0, // ✅ 불필요한 여백 제거
+                        ),
+
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 16, horizontal: 20), // ✅ 내부 여백 추가
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  "AI가 추천하는 제목 ${index + 1}",
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: Colors.grey.shade600,
+                                    fontWeight: isSelected
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  "고민제목이 표시됩니다",
+                                  style: TextStyle(
+                                    fontSize: 20,
+                                    color: isSelected
+                                        ? const Color(0xFFFA743E)
+                                        : Colors.black,
+                                    fontWeight: isSelected
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            Radio<int>(
+                              value: index,
+                              groupValue: _selectedTitleIndex,
+                              activeColor: const Color(0xFFFA743E),
+                              onChanged: (int? value) {
+                                setState(() {
+                                  _selectedTitleIndex = value;
+                                });
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }),
+          ),
+
+          const Spacer(), // 버튼을 아래로 밀어주는 역할
+
+          // 📌 하단 버튼
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20), // ✅ 버튼 패딩 추가
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                // 다시 추천 받기 버튼
+                SizedBox(
+                  width: 150,
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      setState(() {
+                        _selectedTitleIndex = null; // 선택 초기화
+                      });
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(0),
+                      ),
+                      backgroundColor: Colors.grey.shade500,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('다시 추천 받기'),
+                  ),
+                ),
+
+                // 고민 작성하기 버튼
+                SizedBox(
+                  width: 150,
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: _selectedTitleIndex != null
+                        ? () {
+                            // TODO: 고민 작성하기 로직 추가
+                            print("고민 작성 화면으로 이동");
+                          }
+                        : null, // 선택 안하면 비활성화
+                    style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(0),
+                      ),
+                      backgroundColor: _selectedTitleIndex != null
+                          ? const Color(0xFFFA743E)
+                          : Colors.grey.shade300,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const Text('고민 작성하기'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20), // 하단 여백 추가
+        ],
+      ),
+    );
+  }
+}

--- a/lib/worryRegist/ai_worry.dart
+++ b/lib/worryRegist/ai_worry.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class WorryRegist extends StatelessWidget {
-  const WorryRegist({super.key});
+class AiWorry extends StatelessWidget {
+  const AiWorry({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/worryRegist/ai_worry.dart
+++ b/lib/worryRegist/ai_worry.dart
@@ -1,10 +1,241 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+import 'dart:io';
 
-class AiWorry extends StatelessWidget {
+class AiWorry extends StatefulWidget {
   const AiWorry({super.key});
 
   @override
+  _AiWorryState createState() => _AiWorryState();
+}
+
+class _AiWorryState extends State<AiWorry> {
+  File? _selectedImage; // 선택한 이미지 파일
+
+  // 📌 이미지 선택 함수 (카메라 or 갤러리)
+  Future<void> _pickImage(ImageSource source) async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: source);
+
+    if (pickedFile != null) {
+      setState(() {
+        _selectedImage = File(pickedFile.path);
+      });
+    }
+    Navigator.pop(context); // 모달 닫기
+  }
+
+  // 📌 사진 추가 모달 (카메라 or 갤러리 선택)
+  void _showImagePickerOptions() {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.zero,
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Wrap(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.camera_alt),
+                title: const Text("카메라로 찍기"),
+                onTap: () => _pickImage(ImageSource.camera),
+              ),
+              ListTile(
+                leading: const Icon(Icons.photo_library),
+                title: const Text("갤러리에서 선택"),
+                onTap: () => _pickImage(ImageSource.gallery),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _startAnalysis() async {
+    // 1. 분석 중 모달 표시
+    showDialog(
+      context: context,
+      barrierDismissible: false, // 바깥 터치로 닫기 방지
+      builder: (context) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  "AI가 이미지를 분석 중입니다",
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 10),
+                const Text(
+                  "조금만 기다리면 AI가 고민 제목을 추천해줍니다",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+                const SizedBox(height: 20),
+                if (_selectedImage != null)
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(5),
+                    child: Image.file(
+                      _selectedImage!,
+                      width: 100,
+                      height: 100,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                const SizedBox(height: 20),
+                const CircularProgressIndicator(),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    // 2. 2초 동안 대기
+    await Future.delayed(const Duration(seconds: 2));
+
+    if (!mounted) return; // 🔥 context가 유효한지 체크
+
+    // 3. 팝업 강제 닫기
+    Navigator.of(context, rootNavigator: true).pop(); // ✅ 팝업 닫기
+
+    // 4. 팝업이 완전히 닫히도록 300ms 추가 대기
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    if (!mounted) return; // 🔥 context가 다시 유효한지 체크
+
+    // 5. 페이지 이동
+    context.go('/aiWorry_analyze'); // 🚀 AiAnalyze 페이지로 이동
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      backgroundColor: Colors.white, // 배경 흰색
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: Colors.white, // AppBar 배경 고정
+          child: SafeArea(
+            child: AppBar(
+              backgroundColor: Colors.transparent, // 투명 처리
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.black),
+                onPressed: () {
+                  context.go('/');
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+      body: Stack(
+        children: [
+          Divider(
+            color: Colors.grey,
+            thickness: 1,
+            height: 1,
+          ),
+          SafeArea(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(30.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(height: 10),
+
+                    // 📌 사진 추가 영역 (이미지 선택 후 표시)
+                    GestureDetector(
+                      onTap: _showImagePickerOptions, // 박스를 누르면 모달 열림
+                      child: Container(
+                        width: double.infinity,
+                        height: 250,
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey), // 회색 테두리
+                          borderRadius: BorderRadius.circular(5), // 모서리 둥글게
+                          color: Colors.white, // 박스 배경 흰색
+                        ),
+                        child: _selectedImage == null
+                            ? Center(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      Icons.add_photo_alternate_outlined,
+                                      size: 40,
+                                      color: Colors.grey,
+                                    ),
+                                    const SizedBox(height: 10),
+                                    const Text(
+                                      "사진 추가하기",
+                                      style: TextStyle(
+                                          color: Colors.black, fontSize: 16),
+                                    ),
+                                  ],
+                                ),
+                              )
+                            : ClipRRect(
+                                borderRadius: BorderRadius.circular(5),
+                                child: Image.file(
+                                  _selectedImage!,
+                                  width: double.infinity,
+                                  height: 250,
+                                  fit: BoxFit.cover, // 사진 크기 맞추기
+                                ),
+                              ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          /// 버튼을 화면 하단 중앙에 배치
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 30), // 하단 여백 추가
+              child: SizedBox(
+                width: 350,
+                height: 50,
+                child: ElevatedButton(
+                  onPressed: _selectedImage != null
+                      ? () => _startAnalysis() // ✅ 버튼을 누르면 _startAnalysis 실행
+                      : () {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text("사진을 추가해주세요!")),
+                          );
+                        },
+                  style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                    backgroundColor: _selectedImage == null
+                        ? Colors.grey.shade300 // ❌ 사진 없을 때 회색 버튼
+                        : Color(0xFFFA743E), // ✅ 사진 있을 때 주황색 버튼
+                    foregroundColor:
+                        _selectedImage == null ? Colors.black : Colors.white,
+                  ),
+                  child: const Text('분석 시작하기'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/worryRegist/ai_worry.dart
+++ b/lib/worryRegist/ai_worry.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'dart:io';
 
@@ -56,273 +55,87 @@ class _AiWorryState extends State<AiWorry> {
     );
   }
 
-  Future<void> _startAnalysis() async {
-    // 1. 분석 중 모달 표시
-    showDialog(
-      context: context,
-      barrierDismissible: false, // 바깥 터치로 닫기 방지
-      builder: (context) {
-        return Dialog(
-          backgroundColor: Colors.white,
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-          child: Padding(
-            padding: const EdgeInsets.all(20),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Text(
-                  "AI가 이미지를 분석 중입니다",
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 10),
-                const Text(
-                  "조금만 기다리면 AI가 고민 제목을 추천해줍니다",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 14, color: Colors.grey),
-                ),
-                const SizedBox(height: 20),
-                if (_selectedImage != null)
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(5),
-                    child: Image.file(
-                      _selectedImage!,
-                      width: 100,
-                      height: 100,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                const SizedBox(height: 20),
-                const CircularProgressIndicator(),
-              ],
-            ),
-          ),
-        );
-      },
-    );
+  // 📌 분석 시작 (AiAnalyze로 이미지 전달)
+  void _startAnalysis() {
+    if (_selectedImage == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("사진을 추가해주세요!")),
+      );
+      return;
+    }
 
-    // 2. 2초 동안 대기
-    await Future.delayed(const Duration(seconds: 2));
-
-    if (!mounted) return; // 🔥 context가 유효한지 체크
-
-    // 3. 팝업 강제 닫기
-    Navigator.of(context, rootNavigator: true).pop(); // ✅ 팝업 닫기
-
-    // 4. 팝업이 완전히 닫히도록 300ms 추가 대기
-    await Future.delayed(const Duration(milliseconds: 300));
-
-    if (!mounted) return; // 🔥 context가 다시 유효한지 체크
-
-    // 5. 페이지 이동
-    context.go('/aiWorry_analyze'); // 🚀 AiAnalyze 페이지로 이동
+    context.push('/aiWorry_analyze', extra: _selectedImage); // ✅ 이미지 전달
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white, // 배경 흰색
-      appBar: PreferredSize(
-        preferredSize: Size.fromHeight(kToolbarHeight),
-        child: Container(
-          color: Colors.white, // 🔥 AppBar 배경 고정
-          child: SafeArea(
-            child: AppBar(
-              backgroundColor:
-                  Colors.transparent, // 🔥 투명하게 해서 Container 색상을 유지
-              elevation: 0,
-              leading: IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.black),
-                onPressed: () {
-                  context.go('/');
-                },
-              ),
-            ),
-          ),
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () {
+            context.go('/aiWorry_analyze', extra: _selectedImage);
+          },
         ),
       ),
-      body: Stack(
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Divider(
-            color: Colors.grey,
-            thickness: 1,
-            height: 1,
-          ),
-          SafeArea(
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.all(30.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox(height: 10),
-                    Container(
-                      width: double.infinity,
-                      height: 250,
-                      decoration: BoxDecoration(
-                        border: Border.all(color: Colors.grey), // 회색 테두리
-                        borderRadius: BorderRadius.circular(5), // 모서리 둥글게
-                        color: Colors.white, // 박스 배경 흰색
-                      ),
-                      child: Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Icon(
-                              Icons.add_photo_alternate_outlined,
-                              size: 40,
-                              color: Colors.grey,
-                            ),
-                            const SizedBox(height: 10),
-                            const Text(
-                              "사진 추가하기",
+          GestureDetector(
+            onTap: _showImagePickerOptions,
+            child: Container(
+              width: double.infinity,
+              height: 250,
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.grey),
+                borderRadius: BorderRadius.circular(5),
+                color: Colors.white,
+              ),
+              child: _selectedImage == null
+                  ? const Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.add_photo_alternate_outlined,
+                              size: 40, color: Colors.grey),
+                          SizedBox(height: 10),
+                          Text("사진 추가하기",
                               style:
-                                  TextStyle(color: Colors.black, fontSize: 16),
-                            ),
-                          ],
-                        ),
+                                  TextStyle(color: Colors.black, fontSize: 16)),
+                        ],
                       ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-
-          /// 버튼을 화면 하단 중앙에 배치
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: 30), // 하단 여백 추가
-              child: SizedBox(
-                width: 350, // 버튼의 너비 조절 (예제: 200px)
-                height: 50, // 버튼의 높이 조절
-                child: ElevatedButton(
-                  onPressed: () {},
-                  style: ElevatedButton.styleFrom(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(0), // 버튼 모서리 둥글게
-                    ),
-                    backgroundColor: Colors.grey.shade300,
-                    foregroundColor: Colors.black,
-                  ),
-                  child: const Text('분석 시작하기'),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-    return Scaffold(
-      backgroundColor: Colors.white, // 배경 흰색
-      appBar: PreferredSize(
-        preferredSize: Size.fromHeight(kToolbarHeight),
-        child: Container(
-          color: Colors.white, // AppBar 배경 고정
-          child: SafeArea(
-            child: AppBar(
-              backgroundColor: Colors.transparent, // 투명 처리
-              elevation: 0,
-              leading: IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.black),
-                onPressed: () {
-                  context.go('/');
-                },
-              ),
-            ),
-          ),
-        ),
-      ),
-      body: Stack(
-        children: [
-          Divider(
-            color: Colors.grey,
-            thickness: 1,
-            height: 1,
-          ),
-          SafeArea(
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.all(30.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox(height: 10),
-
-                    // 📌 사진 추가 영역 (이미지 선택 후 표시)
-                    GestureDetector(
-                      onTap: _showImagePickerOptions, // 박스를 누르면 모달 열림
-                      child: Container(
+                    )
+                  : ClipRRect(
+                      borderRadius: BorderRadius.circular(5),
+                      child: Image.file(
+                        _selectedImage!,
                         width: double.infinity,
                         height: 250,
-                        decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey), // 회색 테두리
-                          borderRadius: BorderRadius.circular(5), // 모서리 둥글게
-                          color: Colors.white, // 박스 배경 흰색
-                        ),
-                        child: _selectedImage == null
-                            ? Center(
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Icon(
-                                      Icons.add_photo_alternate_outlined,
-                                      size: 40,
-                                      color: Colors.grey,
-                                    ),
-                                    const SizedBox(height: 10),
-                                    const Text(
-                                      "사진 추가하기",
-                                      style: TextStyle(
-                                          color: Colors.black, fontSize: 16),
-                                    ),
-                                  ],
-                                ),
-                              )
-                            : ClipRRect(
-                                borderRadius: BorderRadius.circular(5),
-                                child: Image.file(
-                                  _selectedImage!,
-                                  width: double.infinity,
-                                  height: 250,
-                                  fit: BoxFit.cover, // 사진 크기 맞추기
-                                ),
-                              ),
+                        fit: BoxFit.cover,
                       ),
                     ),
-                  ],
-                ),
-              ),
             ),
           ),
 
-          /// 버튼을 화면 하단 중앙에 배치
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: 30), // 하단 여백 추가
+          const Spacer(),
+
+          // 분석 시작하기 버튼
+          Padding(
+            padding: const EdgeInsets.only(bottom: 30),
+            child: Center(
               child: SizedBox(
                 width: 350,
                 height: 50,
                 child: ElevatedButton(
-                  onPressed: _selectedImage != null
-                      ? () => _startAnalysis() // ✅ 버튼을 누르면 _startAnalysis 실행
-                      : () {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text("사진을 추가해주세요!")),
-                          );
-                        },
+                  onPressed: _startAnalysis, // ✅ AI 분석 페이지로 이동 (이미지 전달)
                   style: ElevatedButton.styleFrom(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(0),
-                    ),
                     backgroundColor: _selectedImage == null
-                        ? Colors.grey.shade300 // ❌ 사진 없을 때 회색 버튼
-                        : Color(0xFFFA743E), // ✅ 사진 있을 때 주황색 버튼
-                    foregroundColor:
-                        _selectedImage == null ? Colors.black : Colors.white,
+                        ? Colors.grey.shade300
+                        : Color(0xFFFA743E),
+                    foregroundColor: Colors.white,
                   ),
                   child: const Text('분석 시작하기'),
                 ),

--- a/lib/worryRegist/ai_worry.dart
+++ b/lib/worryRegist/ai_worry.dart
@@ -55,87 +55,179 @@ class _AiWorryState extends State<AiWorry> {
     );
   }
 
-  // 📌 분석 시작 (AiAnalyze로 이미지 전달)
-  void _startAnalysis() {
-    if (_selectedImage == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("사진을 추가해주세요!")),
-      );
-      return;
-    }
+  Future<void> _startAnalysis() async {
+    // 1. 분석 중 모달 표시
+    showDialog(
+      context: context,
+      barrierDismissible: false, // 바깥 터치로 닫기 방지
+      builder: (context) {
+        return Dialog(
+          backgroundColor: Colors.white,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  "AI가 이미지를 분석 중입니다",
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 10),
+                const Text(
+                  "조금만 기다리면 AI가 고민 제목을 추천해줍니다",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+                const SizedBox(height: 20),
+                if (_selectedImage != null)
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(5),
+                    child: Image.file(
+                      _selectedImage!,
+                      width: 100,
+                      height: 100,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                const SizedBox(height: 20),
+                const CircularProgressIndicator(),
+              ],
+            ),
+          ),
+        );
+      },
+    );
 
-    context.push('/aiWorry_analyze', extra: _selectedImage); // ✅ 이미지 전달
+    // 2. 2초 동안 대기
+    await Future.delayed(const Duration(seconds: 2));
+
+    if (!mounted) return; // 🔥 context가 유효한지 체크
+
+    // 3. 팝업 강제 닫기
+    Navigator.of(context, rootNavigator: true).pop(); // ✅ 팝업 닫기
+
+    // 4. 팝업이 완전히 닫히도록 300ms 추가 대기
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    if (!mounted) return; // 🔥 context가 다시 유효한지 체크
+
+    // 5. 페이지 이동
+    context.go('/aiWorryAnalyze'); // 🚀 AiAnalyze 페이지로 이동
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.black),
-          onPressed: () {
-            context.go('/aiWorry_analyze', extra: _selectedImage);
-          },
+      backgroundColor: Colors.white, // 배경 흰색
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: Colors.white, // AppBar 배경 고정
+          child: SafeArea(
+            child: AppBar(
+              backgroundColor: Colors.transparent, // 투명 처리
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.black),
+                onPressed: () {
+                  context.go('/');
+                },
+              ),
+            ),
+          ),
         ),
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      body: Stack(
         children: [
-          GestureDetector(
-            onTap: _showImagePickerOptions,
-            child: Container(
-              width: double.infinity,
-              height: 250,
-              decoration: BoxDecoration(
-                border: Border.all(color: Colors.grey),
-                borderRadius: BorderRadius.circular(5),
-                color: Colors.white,
-              ),
-              child: _selectedImage == null
-                  ? const Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(Icons.add_photo_alternate_outlined,
-                              size: 40, color: Colors.grey),
-                          SizedBox(height: 10),
-                          Text("사진 추가하기",
-                              style:
-                                  TextStyle(color: Colors.black, fontSize: 16)),
-                        ],
-                      ),
-                    )
-                  : ClipRRect(
-                      borderRadius: BorderRadius.circular(5),
-                      child: Image.file(
-                        _selectedImage!,
+          Divider(
+            color: Colors.grey,
+            thickness: 1,
+            height: 1,
+          ),
+          SafeArea(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(30.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(height: 10),
+
+                    // 📌 사진 추가 영역 (이미지 선택 후 표시)
+                    GestureDetector(
+                      onTap: _showImagePickerOptions, // 박스를 누르면 모달 열림
+                      child: Container(
                         width: double.infinity,
                         height: 250,
-                        fit: BoxFit.cover,
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey), // 회색 테두리
+                          borderRadius: BorderRadius.circular(5), // 모서리 둥글게
+                          color: Colors.white, // 박스 배경 흰색
+                        ),
+                        child: _selectedImage == null
+                            ? Center(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(
+                                      Icons.add_photo_alternate_outlined,
+                                      size: 40,
+                                      color: Colors.grey,
+                                    ),
+                                    const SizedBox(height: 10),
+                                    const Text(
+                                      "사진 추가하기",
+                                      style: TextStyle(
+                                          color: Colors.black, fontSize: 16),
+                                    ),
+                                  ],
+                                ),
+                              )
+                            : ClipRRect(
+                                borderRadius: BorderRadius.circular(5),
+                                child: Image.file(
+                                  _selectedImage!,
+                                  width: double.infinity,
+                                  height: 250,
+                                  fit: BoxFit.cover, // 사진 크기 맞추기
+                                ),
+                              ),
                       ),
                     ),
+                  ],
+                ),
+              ),
             ),
           ),
 
-          const Spacer(),
-
-          // 분석 시작하기 버튼
-          Padding(
-            padding: const EdgeInsets.only(bottom: 30),
-            child: Center(
+          /// 버튼을 화면 하단 중앙에 배치
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 30), // 하단 여백 추가
               child: SizedBox(
                 width: 350,
                 height: 50,
                 child: ElevatedButton(
-                  onPressed: _startAnalysis, // ✅ AI 분석 페이지로 이동 (이미지 전달)
+                  onPressed: _selectedImage != null
+                      ? () => _startAnalysis() // ✅ 버튼을 누르면 _startAnalysis 실행
+                      : () {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text("사진을 추가해주세요!")),
+                          );
+                        },
                   style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
                     backgroundColor: _selectedImage == null
-                        ? Colors.grey.shade300
-                        : Color(0xFFFA743E),
-                    foregroundColor: Colors.white,
+                        ? Colors.grey.shade300 // ❌ 사진 없을 때 회색 버튼
+                        : Color(0xFFFA743E), // ✅ 사진 있을 때 주황색 버튼
+                    foregroundColor:
+                        _selectedImage == null ? Colors.black : Colors.white,
                   ),
                   child: const Text('분석 시작하기'),
                 ),

--- a/lib/worryRegist/ai_worry.dart
+++ b/lib/worryRegist/ai_worry.dart
@@ -1,10 +1,104 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class AiWorry extends StatelessWidget {
   const AiWorry({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      backgroundColor: Colors.white, // 배경 흰색
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: Colors.white, // 🔥 AppBar 배경 고정
+          child: SafeArea(
+            child: AppBar(
+              backgroundColor:
+                  Colors.transparent, // 🔥 투명하게 해서 Container 색상을 유지
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.black),
+                onPressed: () {
+                  context.go('/');
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+      body: Stack(
+        children: [
+          Divider(
+            color: Colors.grey,
+            thickness: 1,
+            height: 1,
+          ),
+          SafeArea(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(30.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(height: 10),
+                    Container(
+                      width: double.infinity,
+                      height: 250,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: Colors.grey), // 회색 테두리
+                        borderRadius: BorderRadius.circular(5), // 모서리 둥글게
+                        color: Colors.white, // 박스 배경 흰색
+                      ),
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.add_photo_alternate_outlined,
+                              size: 40,
+                              color: Colors.grey,
+                            ),
+                            const SizedBox(height: 10),
+                            const Text(
+                              "사진 추가하기",
+                              style:
+                                  TextStyle(color: Colors.black, fontSize: 16),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+          /// 버튼을 화면 하단 중앙에 배치
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 30), // 하단 여백 추가
+              child: SizedBox(
+                width: 350, // 버튼의 너비 조절 (예제: 200px)
+                height: 50, // 버튼의 높이 조절
+                child: ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0), // 버튼 모서리 둥글게
+                    ),
+                    backgroundColor: Colors.grey.shade300,
+                    foregroundColor: Colors.black,
+                  ),
+                  child: const Text('분석 시작하기'),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/worryRegist/mainView.dart
+++ b/lib/worryRegist/mainView.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:gomin_jungdok_mobile/navigation_bar.dart';
 import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
 import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/ai_worry.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
-import 'package:gomin_jungdok_mobile/worryRegist/worryRegist.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/normal_worry.dart';
 
 class Mainview extends StatefulWidget {
   const Mainview({super.key});
@@ -18,14 +19,14 @@ class _MainviewState extends State<Mainview> {
   final List<Widget> _tabs = [
     HomeContent(), // 홈
     TodayWorry(), // 오늘의 고민
-    WorryRegist(), // 고민 등록하기
+    Container(), // 고민등록하기
     PastWorry(), // 과거의 고민
-    MyProfile(), // 마이 프로필
+    MyProfile(), // 마이페이지
   ];
 
   void _onTabSelected(int index) {
     setState(() {
-      _currentIndex = index;
+      _currentIndex = index; // 다른 탭 전환
     });
   }
 
@@ -34,12 +35,10 @@ class _MainviewState extends State<Mainview> {
     return Scaffold(
       appBar: AppBar(
         title: Text('앱 메인 화면'),
+        backgroundColor: Colors.white,
       ),
       body: _tabs[_currentIndex], // 현재 선택된 콘텐츠 표시
-      bottomNavigationBar: Navigation_bar(
-        currentIndex: _currentIndex,
-        onTabSelected: _onTabSelected,
-      ),
+      backgroundColor: Colors.white,
     );
   }
 }
@@ -48,7 +47,8 @@ class HomeContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Text('홈 화면 콘텐츠', style: TextStyle(fontSize: 24)),
+      child:
+          Text('홈 화면 콘텐츠', style: TextStyle(fontSize: 24, color: Colors.red)),
     );
   }
 }

--- a/lib/worryRegist/mainView.dart
+++ b/lib/worryRegist/mainView.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:gomin_jungdok_mobile/navigation_bar.dart';
+import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
+import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/worryRegist.dart';
+
+class Mainview extends StatefulWidget {
+  const Mainview({super.key});
+
+  @override
+  _MainviewState createState() => _MainviewState();
+}
+
+class _MainviewState extends State<Mainview> {
+  int _currentIndex = 0;
+
+  final List<Widget> _tabs = [
+    HomeContent(), // 홈
+    TodayWorry(), // 오늘의 고민
+    WorryRegist(), // 고민 등록하기
+    PastWorry(), // 과거의 고민
+    MyProfile(), // 마이 프로필
+  ];
+
+  void _onTabSelected(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('앱 메인 화면'),
+      ),
+      body: _tabs[_currentIndex], // 현재 선택된 콘텐츠 표시
+      bottomNavigationBar: Navigation_bar(
+        currentIndex: _currentIndex,
+        onTabSelected: _onTabSelected,
+      ),
+    );
+  }
+}
+
+class HomeContent extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('홈 화면 콘텐츠', style: TextStyle(fontSize: 24)),
+    );
+  }
+}

--- a/lib/worryRegist/mainView.dart
+++ b/lib/worryRegist/mainView.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:gomin_jungdok_mobile/navigation_bar.dart';
 import 'package:gomin_jungdok_mobile/worry/pastWorry.dart';
 import 'package:gomin_jungdok_mobile/worry/todayWorry.dart';
-import 'package:gomin_jungdok_mobile/worryRegist/ai_worry.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/myProfile.dart';
-import 'package:gomin_jungdok_mobile/worryRegist/normal_worry.dart';
 
 class Mainview extends StatefulWidget {
   const Mainview({super.key});

--- a/lib/worryRegist/myProfile.dart
+++ b/lib/worryRegist/myProfile.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class MyProfile extends StatelessWidget {
+  const MyProfile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/worryRegist/myProfile.dart
+++ b/lib/worryRegist/myProfile.dart
@@ -5,6 +5,14 @@ class MyProfile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      body: Center(
+        child: Text(
+          '마이페이지',
+          style: TextStyle(fontSize: 24, color: Colors.red),
+        ),
+      ),
+      backgroundColor: Colors.white,
+    );
   }
 }

--- a/lib/worryRegist/normal_worry.dart
+++ b/lib/worryRegist/normal_worry.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -14,6 +13,7 @@ class NormalWorry extends StatefulWidget {
 }
 
 class _NormalWorryState extends State<NormalWorry> {
+  final TextEditingController _titleController = TextEditingController();
   final TextEditingController _introController = TextEditingController();
   int _introTextLength = 0;
   int _focusedChoiceIndex = -1; // 선택된 선택지 인덱스
@@ -73,24 +73,14 @@ class _NormalWorryState extends State<NormalWorry> {
       resizeToAvoidBottomInset: false,
       backgroundColor: Colors.white,
       // 선택지를 눌렀을때 appbar의 색상이 변하는
-      // 오류를 해결하는 extedBody-
-      appBar: PreferredSize(
-        preferredSize: Size.fromHeight(kToolbarHeight),
-        child: Container(
-          color: Colors.white, // 🔥 AppBar 배경 고정
-          child: SafeArea(
-            child: AppBar(
-              backgroundColor:
-                  Colors.transparent, // 🔥 투명하게 해서 Container 색상을 유지
-              elevation: 0,
-              leading: IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.black),
-                onPressed: () {
-                  context.go('/');
-                },
-              ),
-            ),
-          ),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () {
+            context.go('/');
+          },
         ),
       ),
       body: Stack(
@@ -109,7 +99,7 @@ class _NormalWorryState extends State<NormalWorry> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      CustomTitleField(),
+                      CustomTitleField(controller: _titleController),
                       CustomIntroField(controller: _introController),
                       BubbleWidget(comment: "필요에 따라 설명에 사진을 추가할 수 있어요"),
                       ImagePickerWidget(
@@ -155,9 +145,15 @@ class _NormalWorryState extends State<NormalWorry> {
   }
 
   Future<void> _submitWorry() async {
-    if (_introController.text.isEmpty ||
-        _choiceControllers[0].text.isEmpty ||
-        _choiceControllers[1].text.isEmpty) {
+    FocusScope.of(context).unfocus();
+    debugPrint("✅ 제목: ${_titleController.text}");
+    debugPrint("✅ 설명: ${_introController.text}");
+    debugPrint("✅ 선택지1: ${_choiceControllers[0].text}");
+    debugPrint("✅ 선택지2: ${_choiceControllers[1].text}");
+    if (_titleController.text.trim().isEmpty ||
+        _introController.text.trim().isEmpty ||
+        _choiceControllers[0].text.trim().isEmpty ||
+        _choiceControllers[1].text.trim().isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text("제목, 설명, 선택지를 모두 입력해주세요.")),
       );
@@ -165,16 +161,25 @@ class _NormalWorryState extends State<NormalWorry> {
     }
 
     try {
+      List<MapEntry<String, MultipartFile>> imageFiles = [];
+      for (var image in _selectedImages) {
+        MultipartFile file =
+            await MultipartFile.fromFile(image.path, filename: image.name);
+        imageFiles.add(MapEntry("images", file)); // ✅ MapEntry로 변환
+      }
+
       FormData formData = FormData.fromMap({
-        "title": _introController.text, // 제목
-        "description": _introController.text, // 고민 설명
-        "option1": _choiceControllers[0].text, // 첫 번째 선택지
-        "option2": _choiceControllers[1].text, // 두 번째 선택지
-        "images": [
-          for (var image in _selectedImages)
-            await MultipartFile.fromFile(image.path, filename: image.name),
-        ]
+        "title": _introController.text.trim(), // 제목
+        "description": _introController.text.trim(), // 고민 설명
+        "option1": _choiceControllers[0].text.trim(), // 첫 번째 선택지
+        "option2": _choiceControllers[1].text.trim(), // 두 번째 선택지
       });
+
+      if (imageFiles.isNotEmpty) {
+        formData.files.addAll(
+          (imageFiles),
+        );
+      }
 
       Response response = await _dio.post(
         "$apiUrl/api/post",
@@ -184,25 +189,43 @@ class _NormalWorryState extends State<NormalWorry> {
         ),
       );
 
+      debugPrint("✅ 응답 코드: ${response.statusCode}");
+      debugPrint("✅ 응답 데이터: ${response.data}");
+
       if (response.statusCode == 201) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text("고민글 작성 완료! 🎉")),
         );
 
         // 입력 필드 초기화
-        setState(() {
-          _introController.clear();
-          _choiceControllers.forEach((controller) => controller.clear());
-          _selectedImages.clear();
-        });
+        _clearFields();
       } else {
         throw Exception("고민글 작성 실패: ${response.statusMessage}");
       }
     } catch (e) {
+      if (e is DioException) {
+        debugPrint("❌ DioException 발생!");
+        debugPrint("❌ 요청 URL: $apiUrl/api/post");
+        debugPrint("❌ 요청 데이터: ${e.requestOptions.data}");
+        debugPrint("❌ 응답 코드: ${e.response?.statusCode}");
+        debugPrint("❌ 응답 데이터: ${e.response?.data}");
+        debugPrint("❌ DioException 메시지: ${e.message}");
+      }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("오류 발생: $e")),
+        SnackBar(content: Text("오류 발생: ${e.toString()}")),
       );
     }
+  }
+
+  void _clearFields() {
+    setState(() {
+      _titleController.clear();
+      _introController.clear();
+      for (var controller in _choiceControllers) {
+        controller.clear();
+      }
+      _selectedImages.clear();
+    });
   }
 
   Widget _buildChoiceField(String label, int index) {
@@ -268,13 +291,17 @@ class _NormalWorryState extends State<NormalWorry> {
 }
 
 class CustomTitleField extends StatefulWidget {
+  final TextEditingController controller; // 🔥 외부에서 컨트롤러를 받음
+
+  const CustomTitleField({required this.controller, Key? key})
+      : super(key: key);
+
   @override
   _CustomTitleFieldState createState() => _CustomTitleFieldState();
 }
 
 class _CustomTitleFieldState extends State<CustomTitleField> {
   bool _isFocused = false;
-  final TextEditingController _controller = TextEditingController();
   final FocusNode _focusNode = FocusNode();
 
   @override
@@ -290,7 +317,6 @@ class _CustomTitleFieldState extends State<CustomTitleField> {
   @override
   void dispose() {
     _focusNode.dispose();
-    _controller.dispose();
     super.dispose();
   }
 
@@ -302,7 +328,7 @@ class _CustomTitleFieldState extends State<CustomTitleField> {
         const SizedBox(height: 5),
         TextField(
           focusNode: _focusNode,
-          controller: _controller,
+          controller: widget.controller, // 🔥 외부에서 받은 컨트롤러 사용
           maxLength: 20,
           decoration: InputDecoration(
             counterStyle: TextStyle(color: Color(0xFFFA743E), fontSize: 12),

--- a/lib/worryRegist/normal_worry.dart
+++ b/lib/worryRegist/normal_worry.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gomin_jungdok_mobile/worryRegist/tooltip_screen.dart';
+import 'package:image_picker/image_picker.dart';
 
 class NormalWorry extends StatefulWidget {
   @override
@@ -10,6 +12,12 @@ class NormalWorry extends StatefulWidget {
 class _NormalWorryState extends State<NormalWorry> {
   final TextEditingController _introController = TextEditingController();
   int _introTextLength = 0;
+  int _focusedChoiceIndex = -1; // 선택된 선택지 인덱스
+  final List<TextEditingController> _choiceControllers = [
+    TextEditingController(),
+    TextEditingController(),
+  ];
+  final List<FocusNode> _choiceFocusNodes = [FocusNode(), FocusNode()];
 
   @override
   void initState() {
@@ -19,137 +27,243 @@ class _NormalWorryState extends State<NormalWorry> {
         _introTextLength = _introController.text.length;
       });
     });
+    for (var i = 0; i < _choiceControllers.length; i++) {
+      _choiceControllers[i].addListener(() {
+        setState(() {});
+      });
+      _choiceFocusNodes[i].addListener(() {
+        setState(() {
+          _focusedChoiceIndex = _choiceFocusNodes[i].hasFocus ? i : -1;
+        });
+      });
+    }
   }
 
   @override
   void dispose() {
     _introController.dispose();
+    for (var controller in _choiceControllers) {
+      controller.dispose();
+    }
+    for (var node in _choiceFocusNodes) {
+      node.dispose();
+    }
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('일반 고민 작성'),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.black),
-          onPressed: () {
-            context.go('/');
-          },
-        ),
-      ),
+      resizeToAvoidBottomInset: false,
       backgroundColor: Colors.white,
-      body: GestureDetector(
-        // 화면 터치 시 키보드 숨기기
-        onTap: () => FocusScope.of(context).unfocus(),
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.all(30.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CustomTitleField(),
-                Divider(
-                  thickness: 1,
-                  color: Colors.grey,
-                ),
-                CustomIntroField(controller: _introController),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 0.0),
-                  child: Text(
-                    '${_introTextLength}/100자',
-                    style: const TextStyle(fontSize: 12, color: Colors.grey),
-                  ),
-                ),
-                SizedBox(height: 20),
-                Row(
-                  children: [
-                    Expanded(
-                      child: _buildChoiceField('첫번째 선택지'),
-                    ),
-                    SizedBox(width: 10),
-                    Expanded(child: _buildChoiceField('두번째 선택지')),
-                  ],
-                ),
-                SizedBox(height: 30),
-                ElevatedButton(
-                  onPressed: () {},
-                  child: Center(child: Text('등록하기')),
-                  style: ElevatedButton.styleFrom(
-                    minimumSize: Size(double.infinity, 50),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.zero,
-                    ),
-                    backgroundColor: Colors.grey.shade300,
-                    foregroundColor: Colors.black,
-                  ),
-                ),
-              ],
+      // 선택지를 눌렀을때 appbar의 색상이 변하는
+      // 오류를 해결하는 extedBody-
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(kToolbarHeight),
+        child: Container(
+          color: Colors.white, // 🔥 AppBar 배경 고정
+          child: SafeArea(
+            child: AppBar(
+              backgroundColor:
+                  Colors.transparent, // 🔥 투명하게 해서 Container 색상을 유지
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back, color: Colors.black),
+                onPressed: () {
+                  context.go('/');
+                },
+              ),
             ),
           ),
         ),
+      ),
+      body: Stack(
+        children: [
+          Divider(
+            color: Colors.grey,
+            thickness: 1,
+            height: 1,
+          ),
+          SafeArea(
+            child: GestureDetector(
+              onTap: () => FocusScope.of(context).unfocus(),
+              child: SingleChildScrollView(
+                child: Padding(
+                  padding: const EdgeInsets.all(30.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      CustomTitleField(),
+                      CustomIntroField(controller: _introController),
+                      BubbleWidget(comment: "필요에 따라 설명에 사진을 추가할 수 있어요"),
+                      ImagePickerWidget(),
+                      SizedBox(
+                        height: 25,
+                      ),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: _buildChoiceField('첫번째 선택지', 0),
+                          ),
+                          SizedBox(width: 10),
+                          Expanded(
+                            child: _buildChoiceField('두번째 선택지', 1),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: 30),
+                      ElevatedButton(
+                        onPressed: () {},
+                        child: Center(child: Text('등록하기')),
+                        style: ElevatedButton.styleFrom(
+                          minimumSize: Size(double.infinity, 50),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.zero,
+                          ),
+                          backgroundColor: Colors.grey.shade300,
+                          foregroundColor: Colors.black,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildChoiceField(String label) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Center(child: Text(label, style: TextStyle(color: Colors.grey))),
-        SizedBox(height: 5),
-        TextField(
-          maxLength: 15,
-          decoration: InputDecoration(
-            contentPadding: EdgeInsets.symmetric(vertical: 30, horizontal: 10),
-            border: OutlineInputBorder(
-              borderSide: BorderSide(color: Colors.grey),
+  Widget _buildChoiceField(String label, int index) {
+    return IntrinsicHeight(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Text(
+              label,
+              style: TextStyle(
+                color: _focusedChoiceIndex == index
+                    ? Color(0xFFFA743E)
+                    : Colors.grey,
+              ),
             ),
-            enabledBorder: OutlineInputBorder(
-              borderSide: BorderSide(color: Colors.grey.shade400),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderSide: BorderSide(color: Colors.grey, width: 1),
-            ),
-            hintText: '내용을 입력하세요',
           ),
-          style: TextStyle(fontSize: 10),
-        ),
-      ],
+          SizedBox(height: 5),
+          Stack(
+            children: [
+              TextField(
+                controller: _choiceControllers[index],
+                focusNode: _choiceFocusNodes[index],
+                maxLength: 15,
+                onChanged: (text) {
+                  setState(() {});
+                },
+                decoration: InputDecoration(
+                  counterText: "", // 기본 counter 숨김
+                  contentPadding:
+                      EdgeInsets.symmetric(vertical: 30, horizontal: 10),
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey.shade400),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Color(0xFFFA743E), width: 1),
+                  ),
+                  hintText: '내용을 입력하세요',
+                ),
+                style: TextStyle(fontSize: 10),
+              ),
+              Positioned(
+                right: 10,
+                bottom: 5,
+                child: AnimatedOpacity(
+                  opacity: _focusedChoiceIndex == index ? 1.0 : 0.0,
+                  duration: Duration(milliseconds: 200),
+                  child: Text(
+                    "${_choiceControllers[index].text.length}/15", // 글자수 표시
+                    style: TextStyle(color: Color(0xFFFA743E), fontSize: 12),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }
 
-class CustomTitleField extends StatelessWidget {
+class CustomTitleField extends StatefulWidget {
+  @override
+  _CustomTitleFieldState createState() => _CustomTitleFieldState();
+}
+
+class _CustomTitleFieldState extends State<CustomTitleField> {
+  bool _isFocused = false;
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(() {
+      setState(() {
+        _isFocused = _focusNode.hasFocus;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 5),
-        Container(
-          height: 50,
-          decoration: BoxDecoration(
-            color: Colors.white,
-            border: Border.all(color: Colors.white),
-            borderRadius: BorderRadius.circular(0),
-          ),
-          child: TextField(
-            maxLength: 20,
-            decoration: const InputDecoration(
-              hintText: '제목을 입력하세요',
-              hintStyle: TextStyle(
-                fontSize: 20,
-                color: Colors.grey,
+        TextField(
+          focusNode: _focusNode,
+          controller: _controller,
+          maxLength: 20,
+          decoration: InputDecoration(
+            counterStyle: TextStyle(color: Color(0xFFFA743E), fontSize: 12),
+            hintText: '제목을 입력하세요',
+            hintStyle: TextStyle(
+              fontSize: 20,
+              color: Colors.grey,
+            ),
+            border: UnderlineInputBorder(
+              borderSide: BorderSide(
+                color: _isFocused ? Color(0xFFFA743E) : Colors.grey,
+                width: 2,
               ),
-              border: InputBorder.none,
             ),
-            style: const TextStyle(
-              fontSize: 15,
+            enabledBorder: UnderlineInputBorder(
+              borderSide: BorderSide(
+                color: Colors.grey,
+                width: 1,
+              ),
             ),
+            focusedBorder: UnderlineInputBorder(
+              borderSide: BorderSide(
+                color: Color(0xFFFA743E),
+                width: 2,
+              ),
+            ),
+            counterText: _isFocused ? null : "", // 글자수 제한 표시를 입력 중일 때만
+          ),
+          style: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold, // 입력 시 볼드 처리
           ),
         ),
       ],
@@ -157,40 +271,204 @@ class CustomTitleField extends StatelessWidget {
   }
 }
 
-class CustomIntroField extends StatelessWidget {
+class CustomIntroField extends StatefulWidget {
   final TextEditingController controller;
 
   CustomIntroField({required this.controller});
 
   @override
+  State<CustomIntroField> createState() => _CustomIntroFieldState();
+}
+
+class _CustomIntroFieldState extends State<CustomIntroField> {
+  bool _isFocused = false;
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(() {
+      setState(() {
+        _isFocused = _focusNode.hasFocus;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 5),
-        Container(
-          height: 180,
-          decoration: BoxDecoration(
-            color: Colors.white,
-            border: Border.all(color: Colors.white),
-            borderRadius: BorderRadius.circular(0),
-          ),
-          child: TextField(
-            controller: controller,
-            maxLines: 4,
-            inputFormatters: [
-              LengthLimitingTextInputFormatter(100),
-            ],
-            decoration: const InputDecoration(
-              hintText: '설명을 입력하세요',
-              hintStyle: TextStyle(
-                fontSize: 12,
-                color: Colors.grey,
+        Stack(
+          children: [
+            Container(
+              height: 200,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: Colors.white),
+                borderRadius: BorderRadius.circular(0),
               ),
-              border: InputBorder.none,
+              child: TextField(
+                focusNode: _focusNode,
+                controller: widget.controller,
+                maxLines: 4,
+                inputFormatters: [
+                  LengthLimitingTextInputFormatter(100),
+                ],
+                onChanged: (text) {
+                  setState(() {});
+                },
+                decoration: InputDecoration(
+                  hintText: '100자 이내로 고민에 대해 설명해주세요.\n고민은 당일 24시가 되면 사라집니다.',
+                  hintStyle: const TextStyle(
+                    fontSize: 12,
+                    color: Colors.grey,
+                  ),
+                  border: InputBorder.none,
+                  counterText: "",
+                ),
+                style: const TextStyle(
+                  fontSize: 12,
+                ),
+              ),
             ),
-            style: const TextStyle(
-              fontSize: 12,
+            Positioned(
+              right: 10,
+              bottom: 5,
+              child: AnimatedOpacity(
+                duration: Duration(milliseconds: 200),
+                opacity: _isFocused ? 1.0 : 0.0,
+                child: Text(
+                  "${widget.controller.text.length}/100",
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Color(0xFFFA743E),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class ImagePickerWidget extends StatefulWidget {
+  @override
+  _ImagePickerWidgetState createState() => _ImagePickerWidgetState();
+}
+
+class _ImagePickerWidgetState extends State<ImagePickerWidget> {
+  final ImagePicker _picker = ImagePicker();
+  final List<XFile> _selectedImages = [];
+
+  // 갤러리에서 이미지 선택
+  Future<void> _pickImages() async {
+    final List<XFile>? images = await _picker.pickMultiImage();
+
+    if (images != null) {
+      setState(() {
+        // 최대 4개까지만 추가 가능하도록 제한
+        if (_selectedImages.length + images.length <= 4) {
+          _selectedImages.addAll(images);
+        } else {
+          int spaceLeft = 4 - _selectedImages.length;
+          _selectedImages.addAll(images.take(spaceLeft));
+        }
+      });
+    }
+  }
+
+  // 이미지 삭제
+  void _removeImage(int index) {
+    setState(() {
+      _selectedImages.removeAt(index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        GestureDetector(
+          onTap: _pickImages,
+          child: Container(
+            width: 60,
+            height: 60,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10),
+              border:
+                  Border.all(color: const Color.fromARGB(255, 189, 189, 189)),
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.camera_alt, size: 24, color: Colors.grey),
+                Text.rich(TextSpan(children: [
+                  TextSpan(
+                    text: "${_selectedImages.length}",
+                    style: TextStyle(
+                      color: Color(0xFFFA743E),
+                      fontSize: 12,
+                    ),
+                  ),
+                  TextSpan(
+                      text: "/4",
+                      style: TextStyle(
+                        color: Colors.grey,
+                        fontSize: 12,
+                      )),
+                ])),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(
+          width: 10,
+        ),
+
+        // 선택한 이미지 리스트
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: _selectedImages.asMap().entries.map((entry) {
+                int index = entry.key;
+                XFile image = entry.value;
+                return Stack(
+                  alignment: Alignment.topRight,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(10),
+                      child: Image.asset(
+                        image.path,
+                        width: 60,
+                        height: 60,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () => _removeImage(index),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: Colors.black54,
+                        ),
+                        child: Icon(Icons.close, size: 16, color: Colors.white),
+                      ),
+                    ),
+                  ],
+                );
+              }).toList(),
+              spacing: 10,
             ),
           ),
         ),

--- a/lib/worryRegist/normal_worry.dart
+++ b/lib/worryRegist/normal_worry.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+
+class NormalWorry extends StatefulWidget {
+  @override
+  _NormalWorryState createState() => _NormalWorryState();
+}
+
+class _NormalWorryState extends State<NormalWorry> {
+  final TextEditingController _introController = TextEditingController();
+  int _introTextLength = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _introController.addListener(() {
+      setState(() {
+        _introTextLength = _introController.text.length;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _introController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('일반 고민 작성'),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () {
+            context.go('/');
+          },
+        ),
+      ),
+      backgroundColor: Colors.white,
+      body: GestureDetector(
+        // 화면 터치 시 키보드 숨기기
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(30.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CustomTitleField(),
+                Divider(
+                  thickness: 1,
+                  color: Colors.grey,
+                ),
+                CustomIntroField(controller: _introController),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                  child: Text(
+                    '${_introTextLength}/100자',
+                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ),
+                SizedBox(height: 20),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _buildChoiceField('첫번째 선택지'),
+                    ),
+                    SizedBox(width: 10),
+                    Expanded(child: _buildChoiceField('두번째 선택지')),
+                  ],
+                ),
+                SizedBox(height: 30),
+                ElevatedButton(
+                  onPressed: () {},
+                  child: Center(child: Text('등록하기')),
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: Size(double.infinity, 50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.zero,
+                    ),
+                    backgroundColor: Colors.grey.shade300,
+                    foregroundColor: Colors.black,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChoiceField(String label) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Center(child: Text(label, style: TextStyle(color: Colors.grey))),
+        SizedBox(height: 5),
+        TextField(
+          maxLength: 15,
+          decoration: InputDecoration(
+            contentPadding: EdgeInsets.symmetric(vertical: 30, horizontal: 10),
+            border: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.grey),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.grey.shade400),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Colors.grey, width: 1),
+            ),
+            hintText: '내용을 입력하세요',
+          ),
+          style: TextStyle(fontSize: 10),
+        ),
+      ],
+    );
+  }
+}
+
+class CustomTitleField extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 5),
+        Container(
+          height: 50,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: Colors.white),
+            borderRadius: BorderRadius.circular(0),
+          ),
+          child: TextField(
+            maxLength: 20,
+            decoration: const InputDecoration(
+              hintText: '제목을 입력하세요',
+              hintStyle: TextStyle(
+                fontSize: 20,
+                color: Colors.grey,
+              ),
+              border: InputBorder.none,
+            ),
+            style: const TextStyle(
+              fontSize: 15,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class CustomIntroField extends StatelessWidget {
+  final TextEditingController controller;
+
+  CustomIntroField({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 5),
+        Container(
+          height: 180,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: Colors.white),
+            borderRadius: BorderRadius.circular(0),
+          ),
+          child: TextField(
+            controller: controller,
+            maxLines: 4,
+            inputFormatters: [
+              LengthLimitingTextInputFormatter(100),
+            ],
+            decoration: const InputDecoration(
+              hintText: '설명을 입력하세요',
+              hintStyle: TextStyle(
+                fontSize: 12,
+                color: Colors.grey,
+              ),
+              border: InputBorder.none,
+            ),
+            style: const TextStyle(
+              fontSize: 12,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/worryRegist/normal_worry.dart
+++ b/lib/worryRegist/normal_worry.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:gomin_jungdok_mobile/common/const/apiUrl.dart';
 import 'package:gomin_jungdok_mobile/worryRegist/tooltip_screen.dart';
 import 'package:image_picker/image_picker.dart';
 
@@ -18,6 +22,11 @@ class _NormalWorryState extends State<NormalWorry> {
     TextEditingController(),
   ];
   final List<FocusNode> _choiceFocusNodes = [FocusNode(), FocusNode()];
+  final List<XFile> _selectedImages = [];
+  final ImagePicker _picker = ImagePicker();
+
+  final Dio _dio = Dio(); // 서버와의 통신을 위함!
+  final String apiUrl = apiURL;
 
   @override
   void initState() {
@@ -37,6 +46,13 @@ class _NormalWorryState extends State<NormalWorry> {
         });
       });
     }
+  }
+
+  void _updateImages(List<XFile> newImages) {
+    setState(() {
+      _selectedImages.clear();
+      _selectedImages.addAll(newImages);
+    });
   }
 
   @override
@@ -96,7 +112,10 @@ class _NormalWorryState extends State<NormalWorry> {
                       CustomTitleField(),
                       CustomIntroField(controller: _introController),
                       BubbleWidget(comment: "필요에 따라 설명에 사진을 추가할 수 있어요"),
-                      ImagePickerWidget(),
+                      ImagePickerWidget(
+                        selectedImages: _selectedImages,
+                        onImageSelected: _updateImages,
+                      ),
                       SizedBox(
                         height: 25,
                       ),
@@ -113,7 +132,7 @@ class _NormalWorryState extends State<NormalWorry> {
                       ),
                       SizedBox(height: 30),
                       ElevatedButton(
-                        onPressed: () {},
+                        onPressed: _submitWorry,
                         child: Center(child: Text('등록하기')),
                         style: ElevatedButton.styleFrom(
                           minimumSize: Size(double.infinity, 50),
@@ -133,6 +152,57 @@ class _NormalWorryState extends State<NormalWorry> {
         ],
       ),
     );
+  }
+
+  Future<void> _submitWorry() async {
+    if (_introController.text.isEmpty ||
+        _choiceControllers[0].text.isEmpty ||
+        _choiceControllers[1].text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("제목, 설명, 선택지를 모두 입력해주세요.")),
+      );
+      return;
+    }
+
+    try {
+      FormData formData = FormData.fromMap({
+        "title": _introController.text, // 제목
+        "description": _introController.text, // 고민 설명
+        "option1": _choiceControllers[0].text, // 첫 번째 선택지
+        "option2": _choiceControllers[1].text, // 두 번째 선택지
+        "images": [
+          for (var image in _selectedImages)
+            await MultipartFile.fromFile(image.path, filename: image.name),
+        ]
+      });
+
+      Response response = await _dio.post(
+        "$apiUrl/api/post",
+        data: formData,
+        options: Options(
+          headers: {"Content-Type": "multipart/form-data"},
+        ),
+      );
+
+      if (response.statusCode == 201) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("고민글 작성 완료! 🎉")),
+        );
+
+        // 입력 필드 초기화
+        setState(() {
+          _introController.clear();
+          _choiceControllers.forEach((controller) => controller.clear());
+          _selectedImages.clear();
+        });
+      } else {
+        throw Exception("고민글 작성 실패: ${response.statusMessage}");
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("오류 발생: $e")),
+      );
+    }
   }
 
   Widget _buildChoiceField(String label, int index) {
@@ -361,37 +431,30 @@ class _CustomIntroFieldState extends State<CustomIntroField> {
   }
 }
 
-class ImagePickerWidget extends StatefulWidget {
-  @override
-  _ImagePickerWidgetState createState() => _ImagePickerWidgetState();
-}
+class ImagePickerWidget extends StatelessWidget {
+  final List<XFile> selectedImages;
+  final Function(List<XFile>) onImageSelected;
 
-class _ImagePickerWidgetState extends State<ImagePickerWidget> {
+  ImagePickerWidget(
+      {required this.selectedImages, required this.onImageSelected});
+
   final ImagePicker _picker = ImagePicker();
-  final List<XFile> _selectedImages = [];
 
-  // 갤러리에서 이미지 선택
-  Future<void> _pickImages() async {
+  Future<void> _pickImages(BuildContext context) async {
     final List<XFile>? images = await _picker.pickMultiImage();
-
     if (images != null) {
-      setState(() {
-        // 최대 4개까지만 추가 가능하도록 제한
-        if (_selectedImages.length + images.length <= 4) {
-          _selectedImages.addAll(images);
-        } else {
-          int spaceLeft = 4 - _selectedImages.length;
-          _selectedImages.addAll(images.take(spaceLeft));
-        }
-      });
+      if (selectedImages.length + images.length > 4) {
+        int spaceLeft = 4 - selectedImages.length;
+        onImageSelected([...selectedImages, ...images.take(spaceLeft)]);
+      } else {
+        onImageSelected([...selectedImages, ...images]);
+      }
     }
   }
 
-  // 이미지 삭제
   void _removeImage(int index) {
-    setState(() {
-      _selectedImages.removeAt(index);
-    });
+    List<XFile> updatedList = List.from(selectedImages)..removeAt(index);
+    onImageSelected(updatedList);
   }
 
   @override
@@ -399,7 +462,7 @@ class _ImagePickerWidgetState extends State<ImagePickerWidget> {
     return Row(
       children: [
         GestureDetector(
-          onTap: _pickImages,
+          onTap: () => _pickImages(context),
           child: Container(
             width: 60,
             height: 60,
@@ -414,7 +477,7 @@ class _ImagePickerWidgetState extends State<ImagePickerWidget> {
                 Icon(Icons.camera_alt, size: 24, color: Colors.grey),
                 Text.rich(TextSpan(children: [
                   TextSpan(
-                    text: "${_selectedImages.length}",
+                    text: "${selectedImages.length}",
                     style: TextStyle(
                       color: Color(0xFFFA743E),
                       fontSize: 12,
@@ -431,16 +494,14 @@ class _ImagePickerWidgetState extends State<ImagePickerWidget> {
             ),
           ),
         ),
-        SizedBox(
-          width: 10,
-        ),
+        SizedBox(width: 10),
 
         // 선택한 이미지 리스트
         Expanded(
           child: SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: Row(
-              children: _selectedImages.asMap().entries.map((entry) {
+              children: selectedImages.asMap().entries.map((entry) {
                 int index = entry.key;
                 XFile image = entry.value;
                 return Stack(
@@ -448,8 +509,8 @@ class _ImagePickerWidgetState extends State<ImagePickerWidget> {
                   children: [
                     ClipRRect(
                       borderRadius: BorderRadius.circular(10),
-                      child: Image.asset(
-                        image.path,
+                      child: Image.file(
+                        File(image.path), // ✅ Image.asset 대신 Image.file 사용
                         width: 60,
                         height: 60,
                         fit: BoxFit.cover,
@@ -468,7 +529,6 @@ class _ImagePickerWidgetState extends State<ImagePickerWidget> {
                   ],
                 );
               }).toList(),
-              spacing: 10,
             ),
           ),
         ),

--- a/lib/worryRegist/tooltip_screen.dart
+++ b/lib/worryRegist/tooltip_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class BubbleWidget extends StatefulWidget {
+  final String comment;
+  final Color backgroundColor;
+  final Color textColor;
+
+  const BubbleWidget({
+    Key? key,
+    required this.comment,
+    this.backgroundColor = const Color(0xFFFA743E),
+    this.textColor = Colors.white,
+  }) : super(key: key);
+
+  @override
+  _BubbleWidgetState createState() => _BubbleWidgetState();
+}
+
+class _BubbleWidgetState extends State<BubbleWidget> {
+  bool _isVisible = true; // 🔥 말풍선 표시 여부
+
+  void hideTooltip() {
+    setState(() {
+      _isVisible = false; // 🔥 말풍선을 사라지게 변경
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque, // 🔥 터치 이벤트가 빈 공간에서도 감지되도록 설정
+      onTap: hideTooltip, // 🔥 아무 곳이나 누르면 사라짐
+      child: AnimatedSwitcher(
+        duration: Duration(milliseconds: 300), // 🔥 부드럽게 사라지도록 설정
+        child: _isVisible
+            ? CustomPaint(
+                key: ValueKey<bool>(
+                    _isVisible), // 🔥 AnimatedSwitcher가 변화를 감지하도록 설정
+                painter: BubblePainter(widget.backgroundColor),
+                child: Container(
+                  width: 238,
+                  height: 40,
+                  padding:
+                      EdgeInsets.only(left: 12, right: 12, top: 7, bottom: 15),
+                  child: Text(
+                    widget.comment,
+                    style: TextStyle(
+                      color: widget.textColor,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              )
+            : SizedBox(height: 40), // 🔥 말풍선 크기만큼 유지하여 UI 밀림 방지
+      ),
+    );
+  }
+}
+
+// ✅ 말풍선 + 화살표 CustomPainter (UI 확정)
+class BubblePainter extends CustomPainter {
+  final Color color;
+  BubblePainter(this.color);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    Paint paint = Paint()..color = color;
+    double radius = 8.0;
+    double arrowWidth = 10.0;
+    double arrowHeight = 10.0;
+
+    Path path = Path()
+      ..moveTo(radius, 0)
+      ..lineTo(size.width - radius, 0)
+      ..quadraticBezierTo(size.width, 0, size.width, radius)
+      ..lineTo(size.width, size.height - radius - arrowHeight)
+      ..quadraticBezierTo(size.width, size.height - arrowHeight,
+          size.width - radius, size.height - arrowHeight)
+      ..lineTo(23 + radius, size.height - arrowHeight)
+      ..lineTo(20 + arrowWidth / 2, size.height)
+      ..lineTo(24 - arrowWidth / 2, size.height - arrowHeight)
+      ..lineTo(radius, size.height - arrowHeight)
+      ..quadraticBezierTo(
+          0, size.height - arrowHeight, 0, size.height - radius - arrowHeight)
+      ..lineTo(0, radius)
+      ..quadraticBezierTo(0, 0, radius, 0)
+      ..close();
+
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
+}

--- a/lib/worryRegist/worryRegist.dart
+++ b/lib/worryRegist/worryRegist.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class WorryRegist extends StatelessWidget {
+  const WorryRegist({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,43 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -57,6 +65,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -70,8 +110,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.24"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -83,6 +136,94 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.8.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "04539267a740931c6d4479a10d466717ca5901c6fdfd3fcda09391bbb8ebd651"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+20"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   leak_tracker:
     dependency: transitive
     description:
@@ -115,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   lucide_icons:
     dependency: "direct main"
     description:
@@ -147,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -155,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -224,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.6.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.24.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: d3a89184101baec7f4600d58840a764d2ef760fe1c5a20ef9e6b0e9b24a07a3a
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -107,6 +115,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  lucide_icons:
+    dependency: "direct main"
+    description:
+      name: lucide_icons
+      sha256: ad24d0fd65707e48add30bebada7d90bff2a1bba0a72d6e9b19d44246b0e83c4
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.257.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  keyboard_avoider:
+    dependency: "direct main"
+    description:
+      name: keyboard_avoider
+      sha256: d2917bd52c6612bf8d1ff97f74049ddf3592a81d44e814f0e7b07dcfd245b75c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -83,6 +88,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.8.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "04539267a740931c6d4479a10d466717ca5901c6fdfd3fcda09391bbb8ebd651"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -115,6 +128,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   lucide_icons:
     dependency: "direct main"
     description:
@@ -226,4 +247,4 @@ packages:
     version: "14.3.0"
 sdks:
   dart: ">=3.6.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -128,11 +128,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -149,8 +144,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.0"
-<<<<<<< HEAD
-=======
   http:
     dependency: transitive
     description:
@@ -179,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
+      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+20"
+    version: "0.8.12+21"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -239,7 +232,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
->>>>>>> handler/worryImg/kwon
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: e485c7a39ff2b384fa1d7e09b4e25f755804de8384358049124830b04fc4f93a
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -93,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -128,11 +144,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -149,8 +160,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.0"
-<<<<<<< HEAD
-=======
   http:
     dependency: transitive
     description:
@@ -179,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: b62d34a506e12bb965e824b6db4fbf709ee4589cf5d3e99b45ab2287b008ee0c
+      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+20"
+    version: "0.8.12+21"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -239,7 +248,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
->>>>>>> handler/worryImg/kwon
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   font_awesome_flutter: ^10.8.0
   go_router: ^14.8.0
   image_picker: ^1.1.2
+  keyboard_avoider: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   lucide_icons: ^0.257.0
   font_awesome_flutter: ^10.8.0
+  go_router: ^14.8.0
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   go_router: ^14.8.0
   image_picker: ^1.1.2
   keyboard_avoider: ^0.2.0
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  lucide_icons: ^0.257.0
+  font_awesome_flutter: ^10.8.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   lucide_icons: ^0.257.0
   font_awesome_flutter: ^10.8.0
+  go_router: ^14.8.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_windows/file_selector_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
**데모데이 전까지 구현된 코드들입니다.**


### lib

- common/const/apiUrl.dart
   -> 서버 url 주소
- **worry/pastWorry.dart, todayWorry.dart**
   -> 아직 구현 안된 부분(네비게이션에서 누르면 나오게)
- worryRegist
   ->/ai_analyze.dart = 아직 연결안된 ai 때문에 하드코딩으로 ai가 추천해 
       준 제목을 보여주는 페이지
   ->/ai_worry.dart = 갤러리에서 사진 등록 및 카메라 사진 등록 후 팝업 하 
       드코딩 페이지
   ->/mainView.dart = 나머지 두분께서 개발해주시는 메인 페이지라고 생각 
       해서 네비게이션바가 작동하게만 하도록 했음
   ->**/myProfile.dart** = 아직 구현 안된 부분(네비게이션에서 누르면 나오게)
   ->/normal_worry.dart = 일반고민등록 부분(api연결 코드)
   ->/tooltip_screen.dart = 일반고민등록 부분에 주황색 툴팁이 있는데 이 
       것을 구현하는게 어려워서 따로 파일로 만들었음

- go_router.dart = 페이지 전환하는 루트 코드, 현재 navigation bar를 페이지 어느곳으로 가도 나오게끔 구현하기 위해서 ShellRoute를 사용해서 모든 루트들을 묶어두었음, 또한 고민등록 버튼을 눌렀을때 나오는 일반 고민 작성, AI고민 작성 팝업 코드를 작성해놓았음(따로하는게 좋긴하지만 눌렀을때의 경로를 index로 설정해놓아서 index가 2일때를 여기 안에서 컨트롤하는게 나을거라고 생각했음..)

- main.dart = 시작 페이지

- navigation_bar.dart = 네비게이션 UI 페이지

위 파일 중에서 
lib/worry/pastWorry.dart
lib/worry/todayWorry.dart
lib/worryRegist/myProfile.dart
이 3개의 파일은 구현없이 페이지네이션 확인을 위한 StatelessWidget만 있는 파일입니다.